### PR TITLE
Add Nowcasting GAN/Temporal Discriminators

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,7 @@ satflow.egg-info/*
 *.png
 .env
 satflow/.env
+.idea
+.idea/*
+.git
+.git/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+datasets/*
+datasets
+.github
+.github/*
+dist/*
+satflow/logs/
+satflow/logs/*
+satflow.egg-info/
+satflow.egg-info/*
+.idea/*
+.idea
+.pytest_cache/*
+.pytest_cache
+*.png

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@ satflow.egg-info/*
 .pytest_cache/*
 .pytest_cache
 *.png
+.env
+satflow/.env

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,51 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish Docker image
+
+on:
+  [push]
+  # release:
+  #   types: [published]
+
+jobs:
+  push_to_registries:
+    name: Push Docker image to multiple registries
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKERUSERNAME }}
+          password: ${{ secrets.DOCKERPASSWORD }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: |
+            jacobbieker/satflow
+            ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Build: sudo docker build -t <project_name> .
+# Run: sudo docker run -v $(pwd):/workspace/project --gpus all -it --rm <project_name>
+
+
+FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
+
+
+ENV CONDA_ENV_NAME=satflow
+ENV PYTHON_VERSION=3.8
+
+
+# Basic setup
+RUN apt update
+RUN apt install -y bash \
+                   build-essential \
+                   git \
+                   curl \
+                   ca-certificates \
+                   wget \
+                   && rm -rf /var/lib/apt/lists
+
+
+# Set working directory
+WORKDIR /workspace/project
+
+
+# Install Miniconda and create main env
+ADD https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh miniconda3.sh
+RUN /bin/bash miniconda3.sh -b -p /conda \
+    && echo export PATH=/conda/bin:$PATH >> .bashrc \
+    && rm miniconda3.sh
+ENV PATH="/conda/bin:${PATH}"
+RUN conda create -n ${CONDA_ENV_NAME} python=${PYTHON_VERSION} pytorch::pytorch=1.9 torchvision cudatoolkit=10.2 iris rasterio numpy cartopy satpy matplotlib hydra-core pytorch-lightning optuna eccodes -c conda-forge -c nvidia -c pytorch
+
+
+# Switch to bash shell
+SHELL ["/bin/bash", "-c"]
+
+# Install DeepSpeed and build extensions
+RUN DS_BUILD_OPS=1 pip install deepspeed
+
+# Install requirements
+COPY requirements.txt ./
+RUN source activate ${CONDA_ENV_NAME} \
+    && pip install --no-cache-dir -r requirements.txt \
+    && rm requirements.txt
+
+
+# Set ${CONDA_ENV_NAME} to default virutal environment
+RUN echo "source activate ${CONDA_ENV_NAME}" >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,8 @@ RUN apt install -y bash \
                    curl \
                    ca-certificates \
                    wget \
+                   libaio-dev \
                    && rm -rf /var/lib/apt/lists
-
-
-# Set working directory
-WORKDIR /workspace/project
-
 
 # Install Miniconda and create main env
 ADD https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh miniconda3.sh
@@ -37,7 +33,9 @@ RUN conda create -n ${CONDA_ENV_NAME} python=${PYTHON_VERSION} pytorch::pytorch=
 SHELL ["/bin/bash", "-c"]
 
 # Install DeepSpeed and build extensions
-RUN DS_BUILD_OPS=1 pip install deepspeed
+RUN source activate ${CONDA_ENV_NAME} \
+    && DS_BUILD_OPS=1 pip install deepspeed
+
 
 # Install requirements
 COPY requirements.txt ./
@@ -48,3 +46,6 @@ RUN source activate ${CONDA_ENV_NAME} \
 
 # Set ${CONDA_ENV_NAME} to default virutal environment
 RUN echo "source activate ${CONDA_ENV_NAME}" >> ~/.bashrc
+
+# Cp in the development directory and install
+RUN cp satflow/ . && cd satflow && source activate ${CONDA_ENV_NAME} \ && pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ ENV PYTHON_VERSION=3.8
 
 
 # Basic setup
-RUN apt update
-RUN apt install -y bash \
+RUN apt update && apt install -y bash \
                    build-essential \
                    git \
                    curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ RUN /bin/bash miniconda3.sh -b -p /conda \
     && echo export PATH=/conda/bin:$PATH >> .bashrc \
     && rm miniconda3.sh
 ENV PATH="/conda/bin:${PATH}"
-RUN conda create -n ${CONDA_ENV_NAME} python=${PYTHON_VERSION} pytorch::pytorch=1.9 torchvision cudatoolkit=10.2 iris rasterio numpy cartopy satpy matplotlib hydra-core pytorch-lightning optuna eccodes -c conda-forge -c nvidia -c pytorch
-
+# RUN conda create -n ${CONDA_ENV_NAME} python=${PYTHON_VERSION} pytorch::pytorch=1.9 torchvision cudatoolkit=10.2 iris rasterio numpy cartopy satpy matplotlib hydra-core pytorch-lightning optuna eccodes -c conda-forge -c nvidia -c pytorch
+COPY environment.yml ./
+RUN conda env create --file environment.yml && rm environment.yml
 
 # Switch to bash shell
 SHELL ["/bin/bash", "-c"]
@@ -48,4 +49,5 @@ RUN source activate ${CONDA_ENV_NAME} \
 RUN echo "source activate ${CONDA_ENV_NAME}" >> ~/.bashrc
 
 # Cp in the development directory and install
-RUN cp satflow/ . && cd satflow && source activate ${CONDA_ENV_NAME} \ && pip install -e .
+COPY . ./
+RUN source activate ${CONDA_ENV_NAME} && pip install -e .

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: torch
+name: satflow
 channels:
   - pytorch
   - conda-forge
@@ -7,181 +7,266 @@ dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=1_llvm
   - absl-py=0.13.0=pyhd8ed1ab_0
-  - aiohttp=3.7.4.post0=py37h5e8e339_0
+  - affine=2.3.0=py_0
+  - aiohttp=3.7.4.post0=py38h497a2fe_0
   - alembic=1.6.5=pyhd8ed1ab_0
-  - antlr-python-runtime=4.8=py37hc8dfbb8_2
+  - alsa-lib=1.2.3=h516909a_0
+  - appdirs=1.4.4=pyh9f0ad1d_0
+  - asciitree=0.3.3=py_2
   - async-timeout=3.0.1=py_1000
+  - attrs=21.2.0=pyhd8ed1ab_0
   - backports=1.0=py_2
   - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
-  - blas=1.0=mkl
+  - blas=2.110=mkl
+  - blas-devel=3.9.0=10_mkl
   - blinker=1.4=py_1
-  - brotlipy=0.7.0=py37h5e8e339_1001
+  - bokeh=2.3.3=py38h578d9bd_0
+  - boost-cpp=1.74.0=hc6e9bd1_3
+  - brotlipy=0.7.0=py38h497a2fe_1001
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.17.1=h7f98852_1
   - ca-certificates=2021.5.30=ha878542_0
+  - cached-property=1.5.2=hd8ed1ab_1
+  - cached_property=1.5.2=pyha770c72_1
   - cachetools=4.2.2=pyhd8ed1ab_0
-  - certifi=2021.5.30=py37h89c1867_0
-  - cffi=1.14.5=py37hc58025e_0
-  - chardet=4.0.0=py37h89c1867_1
-  - click=8.0.1=py37h89c1867_0
+  - cairo=1.16.0=h6cf1ce9_1008
+  - cartopy=0.19.0.post1=py38hc9c980b_0
+  - certifi=2021.5.30=py38h578d9bd_0
+  - cf-units=3.0.1=py38hb5d20a5_0
+  - cffi=1.14.6=py38ha65f79e_0
+  - cfitsio=3.470=hb418390_7
+  - cftime=1.5.0=py38hb5d20a5_0
+  - chardet=4.0.0=py38h578d9bd_1
+  - charset-normalizer=2.0.0=pyhd8ed1ab_0
+  - click=7.1.2=pyh9f0ad1d_0
+  - click-plugins=1.1.1=py_0
   - cliff=3.8.0=pyhd8ed1ab_0
+  - cligj=0.7.2=pyhd8ed1ab_0
+  - cloudpickle=1.6.0=py_0
   - cmaes=0.8.2=pyh44b312d_0
-  - cmd2=2.1.1=py37h89c1867_0
+  - cmd2=2.1.2=py38h578d9bd_0
   - colorama=0.4.4=pyh9f0ad1d_0
-  - colorlog=5.0.1=py37h89c1867_0
-  - cryptography=3.4.7=py37h5d9358c_0
-  - cudatoolkit=11.1.1=h6406543_8
+  - colorlog=5.0.1=py38h578d9bd_0
+  - configobj=5.0.6=py_0
+  - cryptography=3.4.7=py38ha5dfef3_0
+  - cudatoolkit=10.2.89=h8f6ccaa_8
+  - curl=7.78.0=hea6ffbf_0
+  - cycler=0.10.0=py_2
+  - cytoolz=0.11.0=py38h497a2fe_3
+  - dask=2021.7.2=pyhd8ed1ab_0
+  - dask-core=2021.7.2=pyhd8ed1ab_0
   - dataclasses=0.8=pyhc8e2a94_1
-  - ffmpeg=4.3=hf484d3e_0
+  - dbus=1.13.6=h48d8840_2
+  - distributed=2021.7.2=py38h578d9bd_0
+  - docutils=0.17.1=py38h578d9bd_0
+  - donfig=0.6.0=pyhd8ed1ab_0
+  - eccodes=2.21.0=ha0e6eb6_0
+  - expat=2.4.1=h9c3ff4c_0
+  - fasteners=0.16=pyhd8ed1ab_0
+  - fontconfig=2.13.1=hba837de_1005
   - freetype=2.10.4=h0708190_1
-  - fsspec=2021.6.0=pyhd8ed1ab_0
-  - future=0.18.2=py37h89c1867_3
-  - gmp=6.2.1=h58526e2_0
-  - gnutls=3.6.13=h85f3911_1
-  - google-auth=1.30.2=pyh6c4a22f_0
+  - freexl=1.0.6=h7f98852_0
+  - fsspec=2021.7.0=pyhd8ed1ab_0
+  - future=0.18.2=py38h578d9bd_3
+  - geos=3.9.1=h9c3ff4c_2
+  - geotiff=1.6.0=h2b14fbe_4
+  - gettext=0.19.8.1=h0b5b191_1005
+  - giflib=5.2.1=h36c2ea0_2
+  - glib=2.68.3=h9c3ff4c_0
+  - glib-tools=2.68.3=h9c3ff4c_0
+  - google-auth=1.34.0=pyh6c4a22f_0
   - google-auth-oauthlib=0.4.1=py_2
-  - greenlet=1.1.0=py37hcd2ae1e_0
-  - grpcio=1.38.1=py37hb27c1af_0
-  - idna=2.10=pyh9f0ad1d_0
-  - importlib-metadata=4.5.0=py37h89c1867_0
-  - importlib_metadata=4.5.0=hd8ed1ab_0
-  - importlib_resources=5.1.4=pyhd8ed1ab_0
-  - jpeg=9b=h024ee3a_2
-  - lame=3.100=h7f98852_1001
-  - ld_impl_linux-64=2.35.1=hea4e1c9_2
+  - greenlet=1.1.0=py38h709712a_0
+  - grpcio=1.38.1=py38hdd6454d_0
+  - gst-plugins-base=1.18.4=hf529b03_2
+  - gstreamer=1.18.4=h76c114f_2
+  - h5py=3.3.0=nompi_py38h9915d05_100
+  - hdf4=4.2.15=h10796ff_3
+  - hdf5=1.10.6=nompi_h6a2412b_1114
+  - heapdict=1.0.1=py_0
+  - icu=68.1=h58526e2_0
+  - idna=3.1=pyhd3deb0d_0
+  - importlib-metadata=4.6.3=py38h578d9bd_0
+  - iris=3.0.4=py38h578d9bd_0
+  - jasper=1.900.1=h07fcdf6_1006
+  - jinja2=3.0.1=pyhd8ed1ab_0
+  - jpeg=9d=h36c2ea0_0
+  - json-c=0.15=h98cffda_0
+  - kealib=1.4.14=hcc255d8_2
+  - kiwisolver=1.3.1=py38h1fd1430_1
+  - krb5=1.19.2=hcc1bbae_0
+  - lcms2=2.12=hddcbb42_0
+  - ld_impl_linux-64=2.36.1=hea4e1c9_2
+  - libaec=1.0.5=h9c3ff4c_0
+  - libblas=3.9.0=10_mkl
+  - libcblas=3.9.0=10_mkl
+  - libclang=11.1.0=default_ha53f305_1
+  - libcurl=7.78.0=h2574ce0_0
+  - libdap4=3.20.6=hd7c4107_2
+  - libedit=3.1.20191231=he28a2e2_2
+  - libev=4.33=h516909a_1
+  - libevent=2.1.10=hcdb4288_3
   - libffi=3.3=h58526e2_2
-  - libgcc-ng=9.3.0=h2828fa1_19
-  - libgfortran-ng=7.5.0=h14aa051_19
-  - libgfortran4=7.5.0=h14aa051_19
+  - libgcc-ng=11.1.0=hc902ee8_6
+  - libgdal=3.2.1=h38ff51b_7
+  - libgfortran-ng=11.1.0=h69a702a_6
+  - libgfortran5=11.1.0=h6c583b3_6
+  - libglib=2.68.3=h3e27bee_0
   - libiconv=1.16=h516909a_0
+  - libkml=1.3.0=h238a007_1014
+  - liblapack=3.9.0=10_mkl
+  - liblapacke=3.9.0=10_mkl
+  - libllvm11=11.1.0=hf817b99_2
+  - libnetcdf=4.7.4=nompi_h56d31a8_107
+  - libnghttp2=1.43.0=h812cca2_0
+  - libogg=1.3.4=h7f98852_1
+  - libopus=1.3.1=h7f98852_1
   - libpng=1.6.37=h21135ba_2
-  - libprotobuf=3.17.2=h780b84a_0
-  - libstdcxx-ng=9.3.0=h6de172a_19
-  - libtiff=4.0.9=he6b73bb_1
-  - libuv=1.41.0=h7f98852_0
-  - llvm-openmp=11.1.0=h4bd325d_1
+  - libpq=13.3=hd57d9b9_0
+  - libprotobuf=3.17.2=h780b84a_1
+  - librttopo=1.1.0=h1185371_6
+  - libspatialite=5.0.1=he52d314_3
+  - libssh2=1.9.0=ha56f1ee_6
+  - libstdcxx-ng=11.1.0=h56837e0_6
+  - libtiff=4.2.0=hbd63e13_2
+  - libuuid=2.32.1=h7f98852_1000
+  - libuv=1.42.0=h7f98852_0
+  - libvorbis=1.3.7=h9c3ff4c_0
+  - libwebp-base=1.2.0=h7f98852_2
+  - libxcb=1.13=h7f98852_1003
+  - libxkbcommon=1.0.3=he3ba5ed_0
+  - libxml2=2.9.12=h72842e0_0
+  - llvm-openmp=12.0.1=h4bd325d_1
+  - locket=0.2.0=py_2
+  - lz4-c=1.9.3=h9c3ff4c_1
   - mako=1.1.4=pyh44b312d_0
   - markdown=3.3.4=pyhd8ed1ab_0
-  - markupsafe=2.0.1=py37h5e8e339_0
-  - mkl=2020.4=h726a3e6_304
-  - mkl-service=2.3.0=py37h8f50634_2
-  - mkl_fft=1.3.0=py37h902c9e0_1
-  - mkl_random=1.2.0=py37h9fdb41a_1
-  - multidict=5.1.0=py37h5e8e339_1
+  - markupsafe=2.0.1=py38h497a2fe_0
+  - matplotlib=3.4.2=py38h578d9bd_0
+  - matplotlib-base=3.4.2=py38hcc49a3a_0
+  - mkl=2021.3.0=h726a3e6_557
+  - mkl-devel=2021.3.0=ha770c72_558
+  - mkl-include=2021.3.0=h726a3e6_557
+  - monotonic=1.5=py_0
+  - msgpack-python=1.0.2=py38h1fd1430_1
+  - multidict=5.1.0=py38h497a2fe_1
+  - mysql-common=8.0.25=ha770c72_0
+  - mysql-libs=8.0.25=h935591d_0
   - ncurses=6.2=h58526e2_4
-  - nettle=3.6=he412f7d_0
-  - numpy=1.19.2=py37h54aff64_0
-  - numpy-base=1.19.2=py37hfa32c7d_0
+  - netcdf4=1.5.6=nompi_py38hf887595_102
+  - ninja=1.10.2=h4bd325d_0
+  - nspr=4.30=h9c3ff4c_0
+  - nss=3.67=hb5efdd6_0
+  - numcodecs=0.8.0=py38h709712a_0
   - oauthlib=3.1.1=pyhd8ed1ab_0
   - olefile=0.46=pyh9f0ad1d_1
-  - openh264=2.1.1=h780b84a_0
+  - openjpeg=2.4.0=hb52868f_1
   - openssl=1.1.1k=h7f98852_0
-  - packaging=20.9=pyh44b312d_0
+  - packaging=21.0=pyhd8ed1ab_0
+  - pandas=1.3.1=py38h1abd341_0
+  - partd=1.2.0=pyhd8ed1ab_0
   - pbr=5.6.0=pyhd8ed1ab_0
-  - pip=21.1.2=pyhd8ed1ab_0
+  - pcre=8.45=h9c3ff4c_0
+  - pillow=8.2.0=py38ha0e1e83_1
+  - pip=21.2.2=pyhd8ed1ab_0
+  - pixman=0.40.0=h36c2ea0_0
+  - pooch=1.4.0=pyhd8ed1ab_0
+  - poppler=0.89.0=h2de54a5_5
+  - poppler-data=0.4.10=0
+  - postgresql=13.3=h2510834_0
   - prettytable=2.1.0=pyhd8ed1ab_0
-  - protobuf=3.17.2=py37hcd2ae1e_0
+  - proj=7.2.0=h277dcde_2
+  - protobuf=3.17.2=py38h709712a_0
+  - psutil=5.8.0=py38h497a2fe_1
+  - pthread-stubs=0.4=h36c2ea0_1001
   - pyasn1=0.4.8=py_0
   - pyasn1-modules=0.2.7=py_0
   - pycparser=2.20=pyh9f0ad1d_2
-  - pydeprecate=0.3.0=pyhd8ed1ab_0
+  - pydeprecate=0.3.1=pyhd8ed1ab_0
+  - pyjwt=2.1.0=pyhd8ed1ab_0
+  - pykdtree=1.3.4=py38h0b5ebd8_0
+  - pyke=1.1.1=pyhd8ed1ab_1004
   - pyopenssl=20.0.1=pyhd8ed1ab_0
+  - pyorbital=1.6.1=pyhd8ed1ab_0
   - pyparsing=2.4.7=pyh9f0ad1d_0
   - pyperclip=1.8.2=pyhd8ed1ab_2
-  - pysocks=1.7.1=py37h89c1867_3
-  - python=3.7.10=hffdb5ce_100_cpython
-  - python-dateutil=2.8.1=py_0
+  - pyproj=3.1.0=py38h53229fd_3
+  - pyqt=5.12.3=py38h578d9bd_7
+  - pyqt-impl=5.12.3=py38h7400c14_7
+  - pyqt5-sip=4.19.18=py38h709712a_7
+  - pyqtchart=5.12=py38h7400c14_7
+  - pyqtwebengine=5.12.1=py38h7400c14_7
+  - pyresample=1.20.0=py38h1abd341_0
+  - pyshp=2.1.3=pyh44b312d_0
+  - pysocks=1.7.1=py38h578d9bd_3
+  - pyspectral=0.10.5=pyhd8ed1ab_0
+  - python=3.8.10=h49503c6_1_cpython
+  - python-dateutil=2.8.2=pyhd8ed1ab_0
   - python-editor=1.0.4=py_0
-  - python_abi=3.7=1_cp37m
-  - pytorch=1.9.0=py3.7_cuda11.1_cudnn8.0.5_0
-  - pytorch-lightning=1.3.7=pyhd8ed1ab_0
+  - python-geotiepoints=1.2.1=py38h5c078b8_1
+  - python-xxhash=2.0.2=py38h497a2fe_0
+  - python_abi=3.8=2_cp38
+  - pytorch=1.9.0=py3.8_cuda10.2_cudnn7.6.5_0
+  - pytorch-lightning=1.4.0=pyhd8ed1ab_0
+  - pytz=2021.1=pyhd8ed1ab_0
   - pyu2f=0.1.5=pyhd8ed1ab_0
+  - pyyaml=5.4.1=py38h497a2fe_0
+  - qt=5.12.9=hda022c4_4
+  - rasterio=1.2.6=py38h56add21_0
   - readline=8.1=h46c0cb4_0
-  - requests=2.25.1=pyhd3deb0d_0
+  - requests=2.26.0=pyhd8ed1ab_0
   - requests-oauthlib=1.3.0=pyh9f0ad1d_0
   - rsa=4.7.2=pyh44b312d_0
-  - scipy=1.6.2=py37h91f5cce_0
-  - setuptools=49.6.0=py37h89c1867_3
-  - sqlalchemy=1.4.19=py37h5e8e339_0
+  - satpy=0.29.0=pyhd8ed1ab_0
+  - scipy=1.7.0=py38h7b17777_1
+  - setuptools=49.6.0=py38h578d9bd_3
+  - shapely=1.7.1=py38haeee4fe_5
+  - six=1.16.0=pyh6c4a22f_0
+  - snuggs=1.4.7=py_0
+  - sortedcontainers=2.4.0=pyhd8ed1ab_0
+  - sqlalchemy=1.4.22=py38h497a2fe_0
   - sqlite=3.36.0=h9cd32fc_0
-  - stevedore=3.3.0=py37h89c1867_1
+  - stevedore=3.3.0=py38h578d9bd_1
+  - tbb=2021.3.0=h4bd325d_0
+  - tblib=1.7.0=pyhd8ed1ab_0
   - tensorboard=2.4.1=pyhd8ed1ab_0
   - tensorboard-plugin-wit=1.8.0=pyh44b312d_0
+  - tiledb=2.2.9=h91fcb0e_0
   - tk=8.6.10=h21135ba_1
-  - torchaudio=0.9.0=py37
-  - torchmetrics=0.3.2=pyhd8ed1ab_0
-  - torchvision=0.10.0=py37_cu111
-  - tqdm=4.61.1=pyhd8ed1ab_0
+  - toolz=0.11.1=py_0
+  - torchmetrics=0.4.1=pyhd8ed1ab_0
+  - tornado=6.1=py38h497a2fe_1
+  - tqdm=4.62.0=pyhd8ed1ab_0
+  - trollimage=1.15.1=pyhd8ed1ab_0
+  - trollsift=0.3.5=pyh44b312d_0
   - typing-extensions=3.10.0.0=hd8ed1ab_0
   - typing_extensions=3.10.0.0=pyha770c72_0
-  - urllib3=1.26.5=pyhd8ed1ab_0
+  - tzcode=2021a=h7f98852_2
+  - tzdata=2021a=he74cb21_1
+  - udunits2=2.2.27.27=h975c496_1
+  - urllib3=1.26.6=pyhd8ed1ab_0
   - wcwidth=0.2.5=pyh9f0ad1d_2
   - werkzeug=2.0.1=pyhd8ed1ab_0
   - wheel=0.36.2=pyhd3deb0d_0
+  - xarray=0.19.0=pyhd8ed1ab_1
+  - xerces-c=3.2.3=h9d8b166_2
+  - xorg-kbproto=1.0.7=h7f98852_1002
+  - xorg-libice=1.0.10=h7f98852_0
+  - xorg-libsm=1.2.3=hd9c2040_1000
+  - xorg-libx11=1.7.2=h7f98852_0
+  - xorg-libxau=1.0.9=h7f98852_0
+  - xorg-libxdmcp=1.1.3=h7f98852_0
+  - xorg-libxext=1.3.4=h7f98852_1
+  - xorg-libxrender=0.9.10=h7f98852_1003
+  - xorg-renderproto=0.11.1=h7f98852_1002
+  - xorg-xextproto=7.3.0=h7f98852_1002
+  - xorg-xproto=7.0.31=h7f98852_1007
+  - xxhash=0.8.0=h7f98852_3
   - xz=5.2.5=h516909a_1
   - yaml=0.2.5=h516909a_0
-  - yarl=1.6.3=py37h5e8e339_1
-  - zipp=3.4.1=pyhd8ed1ab_0
+  - yarl=1.6.3=py38h497a2fe_2
+  - zarr=2.8.3=pyhd8ed1ab_0
+  - zict=2.0.0=py_0
+  - zipp=3.5.0=pyhd8ed1ab_0
   - zlib=1.2.11=h516909a_1010
-  - pip:
-      - albumentations==1.0.0
-      - appdirs==1.4.4
-      - attrs==20.3.0
-      - black==21.6b0
-      - braceexpand==0.1.7
-      - cfgv==3.3.0
-      - clearml==1.0.4
-      - clearml-agent==1.0.0
-      - commonmark==0.9.1
-      - cycler==0.10.0
-      - decorator==4.4.2
-      - deepspeed==0.4.0
-      - distlib==0.3.2
-      - filelock==3.0.12
-      - furl==2.1.2
-      - humanfriendly==9.2
-      - hydra-colorlog==1.1.0
-      - hydra-core==1.1.0
-      - hydra-optuna-sweeper==1.1.0
-      - identify==2.2.10
-      - imageio==2.9.0
-      - iniconfig==1.1.1
-      - joblib==1.0.1
-      - jsonschema==3.2.0
-      - kiwisolver==1.3.1
-      - matplotlib==3.4.2
-      - mpi4py==3.0.3
-      - mypy-extensions==0.4.3
-      - networkx==2.5.1
-      - ninja==1.10.0.post2
-      - nodeenv==1.6.0
-      - omegaconf==2.1.0
-      - opencv-python-headless==4.5.2.54
-      - optuna==2.4.0
-      - orderedmultidict==1.0.1
-      - pathlib2==2.3.5
-      - pathspec==0.8.1
-      - pillow==8.2.0
-      - pluggy==0.13.1
-      - pre-commit==2.13.0
-      - psutil==5.8.0
-      - py==1.10.0
-      - pygments==2.9.0
-      - pyhocon==0.3.57
-      - pyjwt==2.0.1
-      - pyrsistent==0.17.3
-      - pytest==6.2.4
-      - python-dotenv==0.18.0
-      - pywavelets==1.1.1
-      - pyyaml==5.3.1
-      - regex==2021.4.4
-      - rich==10.4.0
-      - scikit-image==0.18.1
-      - six==1.15.0
-      - tensorboardx==1.8
-      - tifffile==2021.6.14
-      - toml==0.10.2
-      - triton==0.4.2
-      - typed-ast==1.4.3
-      - typing==3.7.4.3
-      - virtualenv==20.4.7
+  - zstd=1.4.9=ha95c52a_0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ satpy~=0.29.0
 pyresample~=1.20.0
 git+git://github.com/webdataset/webdataset@master
 albumentations~=1.0.0
-pandas~=1.2.4
 matplotlib~=3.4.2
 xarray~=0.18.2
 torch~=1.9.0
+torchvision~=0.10.0
 antialiased-cnns
 pytorch-msssim

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
 affine~=2.3.0
-numpy~=1.20.3
 satpy~=0.29.0
-pyresample~=1.20.0
 git+git://github.com/webdataset/webdataset@master
 albumentations~=1.0.0
-matplotlib~=3.4.2
-xarray~=0.18.2
-torch~=1.9.0
-torchvision~=0.10.0
-antialiased-cnns
-pytorch-msssim
+torchvision==0.10.0
+antialiased-cnns==0.3.0
+pytorch-msssim~=0.2.0
+neptune-client~=0.10.1
+hydra-optuna-sweeper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 affine~=2.3.0
-satpy~=0.29.0
 git+git://github.com/webdataset/webdataset@master
 albumentations~=1.0.0
 torchvision==0.10.0
 antialiased-cnns==0.3.0
-pytorch-msssim~=0.2.0
-neptune-client~=0.10.1
-hydra-optuna-sweeper
+pytorch-msssim==0.2.1
+neptune-client==0.10.2
+hydra-optuna-sweeper==1.1.0

--- a/satflow/configs/config.yaml
+++ b/satflow/configs/config.yaml
@@ -6,7 +6,7 @@ defaults:
   - model: nowcasting_gan.yaml
   - datamodule: nowcasting_gan_hrv.yaml
   - callbacks: default.yaml # set this to null if you don't want to use callbacks
-  - logger: tensorboard # set logger here or use command line (e.g. `python run.py logger=wandb`)
+  - logger: null # set logger here or use command line (e.g. `python run.py logger=wandb`)
 
   - experiment: null
   - hparams_search: null

--- a/satflow/configs/config.yaml
+++ b/satflow/configs/config.yaml
@@ -3,8 +3,8 @@
 # specify here default training configuration
 defaults:
   - trainer: minimal.yaml
-  - model: convlstm_model.yaml
-  - datamodule: satflow_datamodule.yaml
+  - model: nowcasting_gan.yaml
+  - datamodule: nowcasting_gan_hrv.yaml
   - callbacks: default.yaml # set this to null if you don't want to use callbacks
   - logger: tensorboard # set logger here or use command line (e.g. `python run.py logger=wandb`)
 

--- a/satflow/configs/datamodule/nowcasting_gan_hrv.yaml
+++ b/satflow/configs/datamodule/nowcasting_gan_hrv.yaml
@@ -1,0 +1,32 @@
+# @package _group_
+_target_: satflow.data.datamodules.SatFlowDataModule
+
+batch_size: 4A
+data_dir: ${data_dir} # data_dir is specified in config.yaml
+shuffle: 0
+sources:
+  train: "satflow-flow-144-tiled-{00001..00105}.tar"
+  val: "satflow-flow-144-tiled-{00106..00129}.tar"
+  test: "satflow-flow-144-tiled-{00130..00149}.tar"
+num_workers: 12
+pin_memory: True
+config:
+  visualize: False
+  num_timesteps: 3
+  skip_timesteps: 1
+  forecast_times: 12
+  output_shape: 64
+  target_type: "cloudmask"
+  num_crops: 10
+  num_times: 15
+  use_topo: False
+  use_latlon: False
+  use_time: False
+  time_aux: False
+  use_mask: False
+  use_image: True
+  time_as_channels: False
+  add_pixel_coords: False
+  add_polar_coords: False
+  bands: ["HRV"]
+  transforms: {}

--- a/satflow/configs/datamodule/nowcasting_gan_hrv.yaml
+++ b/satflow/configs/datamodule/nowcasting_gan_hrv.yaml
@@ -1,7 +1,7 @@
 # @package _group_
 _target_: satflow.data.datamodules.SatFlowDataModule
 
-batch_size: 4
+batch_size: 5
 data_dir: ${data_dir} # data_dir is specified in config.yaml
 shuffle: 0
 sources:

--- a/satflow/configs/datamodule/nowcasting_gan_hrv.yaml
+++ b/satflow/configs/datamodule/nowcasting_gan_hrv.yaml
@@ -1,7 +1,7 @@
 # @package _group_
 _target_: satflow.data.datamodules.SatFlowDataModule
 
-batch_size: 4A
+batch_size: 4
 data_dir: ${data_dir} # data_dir is specified in config.yaml
 shuffle: 0
 sources:

--- a/satflow/configs/datamodule/nowcasting_gan_hrv.yaml
+++ b/satflow/configs/datamodule/nowcasting_gan_hrv.yaml
@@ -15,7 +15,7 @@ config:
   num_timesteps: 3
   skip_timesteps: 1
   forecast_times: 12
-  output_shape: 256
+  output_shape: 128
   target_type: "cloudmask"
   num_crops: 10
   num_times: 15

--- a/satflow/configs/datamodule/nowcasting_gan_hrv.yaml
+++ b/satflow/configs/datamodule/nowcasting_gan_hrv.yaml
@@ -15,7 +15,7 @@ config:
   num_timesteps: 3
   skip_timesteps: 1
   forecast_times: 12
-  output_shape: 64
+  output_shape: 256
   target_type: "cloudmask"
   num_crops: 10
   num_times: 15

--- a/satflow/configs/logger/neptune.yaml
+++ b/satflow/configs/logger/neptune.yaml
@@ -1,11 +1,8 @@
 # https://neptune.ai
 
 neptune:
-  _target_: pytorch_lightning.loggers.neptune.NeptuneLogger
+  _target_: neptune.new.integrations.pytorch_lightning.NeptuneLogger
   api_key: ${oc.env:NEPTUNE_API_TOKEN} # api key is loaded from environment variable
-  project_name: OpenClimateFix/forecasting-satellite-images
-  close_after_fit: True
-  offline_mode: False
-  experiment_name: null
-  experiment_id: null
+  project: OpenClimateFix/forecasting-satellite-images
+  close_after_fit: False
   prefix: ""

--- a/satflow/configs/model/nowcasting_gan.yaml
+++ b/satflow/configs/model/nowcasting_gan.yaml
@@ -13,3 +13,4 @@ grid_lambda: 20.0
 beta1: 0.0
 beta2: 0.999
 latent_channels: 768
+context_channels: 768

--- a/satflow/configs/model/nowcasting_gan.yaml
+++ b/satflow/configs/model/nowcasting_gan.yaml
@@ -2,7 +2,7 @@
 _target_: satflow.models.nowcasting_gan.NowcastingGAN
 forecast_steps: 12
 input_channels: 1
-output_shape: 256
+output_shape: 128
 gen_lr: 0.00005
 disc_lr: 0.0002
 visualize: True

--- a/satflow/configs/model/nowcasting_gan.yaml
+++ b/satflow/configs/model/nowcasting_gan.yaml
@@ -1,0 +1,15 @@
+# @package _group_
+_target_: satflow.models.nowcasting_gan.NowcastingGAN
+forecast_steps: 12
+input_channels: 1
+output_shape: 128
+gen_lr: 0.00005
+disc_lr: 0.0002
+visualize: True
+pretrained: False
+conv_type: "standard"
+num_samples: 6
+grid_lambda: 20.0
+beta1: 0.0
+beta2: 0.999
+latent_channels: 384

--- a/satflow/configs/model/nowcasting_gan.yaml
+++ b/satflow/configs/model/nowcasting_gan.yaml
@@ -12,4 +12,4 @@ num_samples: 6
 grid_lambda: 20.0
 beta1: 0.0
 beta2: 0.999
-latent_channels: 384
+latent_channels: 768

--- a/satflow/configs/model/nowcasting_gan.yaml
+++ b/satflow/configs/model/nowcasting_gan.yaml
@@ -2,7 +2,7 @@
 _target_: satflow.models.nowcasting_gan.NowcastingGAN
 forecast_steps: 12
 input_channels: 1
-output_shape: 128
+output_shape: 256
 gen_lr: 0.00005
 disc_lr: 0.0002
 visualize: True

--- a/satflow/configs/trainer/minimal.yaml
+++ b/satflow/configs/trainer/minimal.yaml
@@ -6,17 +6,17 @@ gpus: 1
 
 min_epochs: 0
 max_epochs: 99999
-min_steps: 20000
-max_steps: 2000000
-val_check_interval: 1000
+min_steps: 0
+max_steps: 999999999
 limit_train_batches: 2000
 limit_val_batches: 1000
+limit_test_batches: 10000
 
 terminate_on_nan: True
 auto_lr_find: False
 auto_scale_batch_size: False
 accumulate_grad_batches: 1
-precision: 32
+precision: 16
 # stochastic_weight_avg: True
 fast_dev_run: False
 

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -7,7 +7,7 @@ from torch.nn.utils.parametrizations import spectral_norm
 from torch.nn.modules.pixelshuffle import PixelShuffle, PixelUnshuffle
 from torch.nn.functional import interpolate
 from satflow.models.utils import get_conv_layer
-from satflow.models.layers.Attention import SelfAttention
+from satflow.models.layers.Attention import SelfAttention2d
 
 
 def get_norm_layer(norm_type="instance"):
@@ -418,7 +418,9 @@ class LatentConditioningStack(torch.nn.Module):
             input_channels=output_channels // 16, output_channels=output_channels // 4
         )
         if self.use_attention:
-            self.att_block = SelfAttention(in_dim=output_channels // 4)
+            self.att_block = SelfAttention2d(
+                input_dims=output_channels // 4, output_dims=output_channels // 4
+            )
         self.l_block4 = LBlock(
             input_channels=output_channels // 4, output_channels=output_channels
         )

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -216,6 +216,11 @@ class DBlock(torch.nn.Module):
             padding=0 if keep_same_output else 1,
             stride=1 if keep_same_output else 2,
         )
+        if conv_type == "3d":
+            # Need spectrally normalized convolutions
+            self.conv_1x1 = spectral_norm(self.conv_1x1)
+            self.first_conv_3x3 = spectral_norm(self.first_conv_3x3)
+            self.last_conv_3x3 = spectral_norm(self.last_conv_3x3)
         # Downsample at end of 3x3
         self.relu = torch.nn.ReLU()
         # Concatenate to double final channels and keep reduced spatial extent

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -382,6 +382,7 @@ class ContextConditioningStack(torch.nn.Module):
         scale_2 = torch.cat(scale_2, dim=2)  # B, T, C, H, W and want along C dimension
         scale_3 = torch.cat(scale_3, dim=2)  # B, T, C, H, W and want along C dimension
         scale_4 = torch.cat(scale_4, dim=2)  # B, T, C, H, W and want along C dimension
+        # TODO Figure out where extra channels come from, paper says concat outputs and divide channels by 2 gives 48,96,192,384 total, but this gives 8*4 = 32, 16*4 = 64
         scale_1 = self.relu(self.conv1(scale_1))
         scale_2 = self.relu(self.conv1(scale_2))
         scale_3 = self.relu(self.conv1(scale_3))

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -228,13 +228,13 @@ class DBlock(torch.nn.Module):
             in_channels=input_channels,
             out_channels=input_channels,
             kernel_size=3,
-            padding=0 if keep_same_output else 1,
+            padding=1,
         )
         self.last_conv_3x3 = conv2d(
             in_channels=input_channels,
             out_channels=output_channels,
             kernel_size=3,
-            padding=0 if keep_same_output else 1,
+            padding=1,
             stride=1 if keep_same_output else 2,
         )
         if conv_type == "3d":
@@ -255,7 +255,6 @@ class DBlock(torch.nn.Module):
         x = self.first_conv_3x3(x)
         x = self.relu(x)
         x = self.last_conv_3x3(x)
-
         x = x1 + x  # Sum the outputs should be half spatial and double channels
         return x
 

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -6,6 +6,7 @@ from torch.distributions import uniform
 from torch.nn.utils.parametrizations import spectral_norm
 from torch.nn.modules.pixelshuffle import PixelShuffle, PixelUnshuffle
 from satflow.models.utils import get_conv_layer
+from satflow.models.layers.Attention import SelfAttention
 
 
 def get_norm_layer(norm_type="instance"):
@@ -344,7 +345,7 @@ class LatentConditioningStack(torch.nn.Module):
         self.l_block1 = LBlock(input_channels=shape[2], output_channels=24)
         self.l_block2 = LBlock(input_channels=24, output_channels=48)
         self.l_block3 = LBlock(input_channels=48, output_channels=192)
-        self.att_block = None  # TODO Add in attention module
+        self.att_block = SelfAttention(in_dim=192)
         self.l_block4 = LBlock(input_channels=192, output_channels=768)
 
     def forward(self):

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -3,6 +3,7 @@ import functools
 import torch
 from torch.nn import init
 from torch.distributions import uniform
+from torch.nn.utils.parametrizations import spectral_norm
 from satflow.models.utils import get_conv_layer
 
 
@@ -192,6 +193,7 @@ class DBlock(torch.nn.Module):
         output_channels: int = 12,
         conv_type: str = "standard",
         first_relu: bool = True,
+        keep_same_output: bool = False,
     ):
         super().__init__()
         self.first_relu = first_relu
@@ -201,7 +203,7 @@ class DBlock(torch.nn.Module):
             out_channels=output_channels,
             kernel_size=1,
             padding=0,
-            stride=2,
+            stride=1 if keep_same_output else 2,
         )
         # Downsample in the 1x1
         self.first_conv_3x3 = conv2d(
@@ -211,8 +213,8 @@ class DBlock(torch.nn.Module):
             in_channels=input_channels,
             out_channels=output_channels,
             kernel_size=3,
-            padding=1,
-            stride=2,
+            padding=0 if keep_same_output else 1,
+            stride=1 if keep_same_output else 2,
         )
         # Downsample at end of 3x3
         self.relu = torch.nn.ReLU()

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -308,7 +308,7 @@ class ContextConditioningStack(torch.nn.Module):
     def __init__(
         self,
         input_channels: int = 1,
-        output_channels: int = 384,
+        output_channels: int = 768,
         num_context_steps: int = 4,
         conv_type: str = "standard",
     ):
@@ -347,12 +347,12 @@ class ContextConditioningStack(torch.nn.Module):
             output_channels=(output_channels * 2 * input_channels) // num_context_steps,
             conv_type=conv_type,
         )
-
         self.conv1 = spectral_norm(
             conv2d(
                 in_channels=(output_channels // 4) * input_channels,
                 out_channels=(output_channels // 8) * input_channels,
                 kernel_size=3,
+                padding=1,
             )
         )
         self.conv2 = spectral_norm(
@@ -360,6 +360,7 @@ class ContextConditioningStack(torch.nn.Module):
                 in_channels=(output_channels // 2) * input_channels,
                 out_channels=(output_channels // 4) * input_channels,
                 kernel_size=3,
+                padding=1,
             )
         )
         self.conv3 = spectral_norm(
@@ -367,6 +368,7 @@ class ContextConditioningStack(torch.nn.Module):
                 in_channels=output_channels * input_channels,
                 out_channels=(output_channels // 2) * input_channels,
                 kernel_size=3,
+                padding=1,
             )
         )
         self.conv4 = spectral_norm(
@@ -374,6 +376,7 @@ class ContextConditioningStack(torch.nn.Module):
                 in_channels=output_channels * 2 * input_channels,
                 out_channels=output_channels * input_channels,
                 kernel_size=3,
+                padding=1,
             )
         )
 
@@ -431,7 +434,9 @@ class LatentConditioningStack(torch.nn.Module):
         self.use_attention = use_attention
         self.distribution = uniform.Uniform(low=torch.Tensor([0.0]), high=torch.Tensor([1.0]))
 
-        self.conv_3x3 = torch.nn.Conv2d(in_channels=shape[0], out_channels=shape[0], kernel_size=3)
+        self.conv_3x3 = torch.nn.Conv2d(
+            in_channels=shape[0], out_channels=shape[0], kernel_size=3, padding=1
+        )
         self.l_block1 = LBlock(input_channels=shape[0], output_channels=output_channels // 32)
         self.l_block2 = LBlock(
             input_channels=output_channels // 32, output_channels=output_channels // 16

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -175,9 +175,7 @@ class GBlock(torch.nn.Module):
             padding=1,
         )
         self.last_conv_3x3 = conv2d(
-            in_channels=input_channels,
-            out_channels=output_channels,
-            kernel_size=3,
+            in_channels=input_channels, out_channels=output_channels, kernel_size=3, padding=1
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -188,11 +186,12 @@ class GBlock(torch.nn.Module):
         # Branch 2
         x2 = self.bn1(x)
         x2 = self.relu(x2)
-        x2 = self.first_conv_3x3(x2)
+        x2 = self.first_conv_3x3(
+            x2, output_size=(2 * x.size()[-2], 2 * x.size()[-1])
+        )  # Make sure size is doubled
         x2 = self.bn2(x2)
         x2 = self.relu(x2)
         x2 = self.last_conv_3x3(x2)
-
         # Sum combine
         x = x1 + x2
         return x

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -191,8 +191,10 @@ class DBlock(torch.nn.Module):
         input_channels: int = 12,
         output_channels: int = 12,
         conv_type: str = "standard",
+        first_relu: bool = True,
     ):
         super().__init__()
+        self.first_relu = first_relu
         conv2d = get_conv_layer(conv_type)
         self.conv_1x1 = conv2d(
             in_channels=input_channels,
@@ -218,13 +220,13 @@ class DBlock(torch.nn.Module):
 
     def forward(self, x):
         x1 = self.conv_1x1(x)
+        if self.first_relu:
+            x = self.relu(x)
+        x = self.first_conv_3x3(x)
+        x = self.relu(x)
+        x = self.last_conv_3x3(x)
 
-        x2 = self.relu(x)
-        x2 = self.first_conv_3x3(x2)
-        x2 = self.relu(x2)
-        x2 = self.last_conv_3x3(x2)
-
-        x = x1 + x2  # Sum the outputs should be half spatial and double channels
+        x = x1 + x  # Sum the outputs should be half spatial and double channels
         return x
 
 

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -226,7 +226,10 @@ class DBlock(torch.nn.Module):
             kernel_size=1,
         )
         self.first_conv_3x3 = conv2d(
-            in_channels=input_channels, out_channels=input_channels, kernel_size=3
+            in_channels=input_channels,
+            out_channels=input_channels,
+            kernel_size=3,
+            padding=0 if keep_same_output else 1,
         )
         self.last_conv_3x3 = conv2d(
             in_channels=input_channels,
@@ -389,15 +392,15 @@ class ContextConditioningStack(torch.nn.Module):
             scale_2.append(s2)
             scale_3.append(s3)
             scale_4.append(s4)
-        scale_1 = torch.cat(scale_1, dim=2)  # B, T, C, H, W and want along C dimension
-        scale_2 = torch.cat(scale_2, dim=2)  # B, T, C, H, W and want along C dimension
-        scale_3 = torch.cat(scale_3, dim=2)  # B, T, C, H, W and want along C dimension
-        scale_4 = torch.cat(scale_4, dim=2)  # B, T, C, H, W and want along C dimension
+        scale_1 = torch.cat(scale_1, dim=1)  # B, T, C, H, W and want along C dimension
+        scale_2 = torch.cat(scale_2, dim=1)  # B, T, C, H, W and want along C dimension
+        scale_3 = torch.cat(scale_3, dim=1)  # B, T, C, H, W and want along C dimension
+        scale_4 = torch.cat(scale_4, dim=1)  # B, T, C, H, W and want along C dimension
         # TODO Figure out where extra channels come from, paper says concat outputs and divide channels by 2 gives 48,96,192,384 total, but this gives 8*4 = 32, 16*4 = 64
         scale_1 = self.relu(self.conv1(scale_1))
-        scale_2 = self.relu(self.conv1(scale_2))
-        scale_3 = self.relu(self.conv1(scale_3))
-        scale_4 = self.relu(self.conv1(scale_4))
+        scale_2 = self.relu(self.conv2(scale_2))
+        scale_3 = self.relu(self.conv3(scale_3))
+        scale_4 = self.relu(self.conv4(scale_4))
 
         return scale_1, scale_2, scale_3, scale_4
 

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -232,9 +232,29 @@ class LBlock(torch.nn.Module):
         self, input_channels: int = 12, output_channels: int = 12, conv_type: str = "standard"
     ):
         super().__init__()
+        # Output size should be channel_out - channel_in
+        conv2d = get_conv_layer(conv_type)
+        self.conv_1x1 = conv2d(
+            in_channels=input_channels,
+            out_channels=output_channels,
+            kernel_size=1,
+        )
+
+        self.first_conv_3x3 = conv2d(input_channels, out_channels=output_channels, kernel_size=3)
+        self.relu = torch.nn.ReLU()
+        self.last_conv_3x3 = conv2d(
+            in_channels=output_channels, out_channels=output_channels, kernel_size=3
+        )
 
     def forward(self, x):
-        pass
+        x1 = self.conv_1x1(x)
+
+        x2 = self.first_conv_3x3(x)
+        x2 = self.relu(x2)
+        x2 = self.last_conv_3x3(x2)
+
+        x = x2 + (torch.cat((x, x1), dim=1))  # TODO make sure this works
+        return x
 
 
 class LatentConditioningStack(torch.nn.Module):

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -218,6 +218,7 @@ class DBlock(torch.nn.Module):
         super().__init__()
         self.first_relu = first_relu
         self.keep_same_output = keep_same_output
+        self.conv_type = conv_type
         conv2d = get_conv_layer(conv_type)
         self.conv_1x1 = conv2d(
             in_channels=input_channels,
@@ -249,7 +250,9 @@ class DBlock(torch.nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x1 = self.conv_1x1(x)
         if not self.keep_same_output:
-            x1 = interpolate(x1, mode="bilinear", scale_factor=0.5)  # Downscale by half
+            x1 = interpolate(
+                x1, mode="trilinear" if self.conv_type == "3d" else "bilinear", scale_factor=0.5
+            )  # Downscale by half
         if self.first_relu:
             x = self.relu(x)
         x = self.first_conv_3x3(x)

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -159,7 +159,7 @@ class GBlock(torch.nn.Module):
         # Upsample 2D conv
         self.first_conv_3x3 = torch.nn.ConvTranspose2d(
             in_channels=input_channels,
-            out_channels=output_channels,
+            out_channels=input_channels,
             kernel_size=3,
             stride=2,
             padding=1,
@@ -209,7 +209,7 @@ class DBlock(torch.nn.Module):
         )
         # Downsample in the 1x1
         self.first_conv_3x3 = conv2d(
-            in_channels=input_channels, out_channels=output_channels, kernel_size=3
+            in_channels=input_channels, out_channels=input_channels, kernel_size=3
         )
         self.last_conv_3x3 = conv2d(
             in_channels=input_channels,
@@ -265,7 +265,7 @@ class LBlock(torch.nn.Module):
         x2 = self.relu(x2)
         x2 = self.last_conv_3x3(x2)
 
-        x = x2 + (torch.cat((x, x1), dim=1))  # TODO make sure this works
+        x = x2 + (torch.cat((x, x1), dim=1))
         return x
 
 

--- a/satflow/models/gan/common.py
+++ b/satflow/models/gan/common.py
@@ -341,29 +341,29 @@ class ContextConditioningStack(torch.nn.Module):
 
         self.conv1 = spectral_norm(
             conv2d(
-                input_channels=(output_channels // 4) * input_channels,
-                output_channels=(output_channels // 8) * input_channels,
+                in_channels=(output_channels // 4) * input_channels,
+                out_channels=(output_channels // 8) * input_channels,
                 kernel_size=3,
             )
         )
         self.conv2 = spectral_norm(
             conv2d(
-                input_channels=(output_channels // 2) * input_channels,
-                output_channels=(output_channels // 4) * input_channels,
+                in_channels=(output_channels // 2) * input_channels,
+                out_channels=(output_channels // 4) * input_channels,
                 kernel_size=3,
             )
         )
         self.conv3 = spectral_norm(
             conv2d(
-                input_channels=output_channels * input_channels,
-                output_channels=(output_channels // 2) * input_channels,
+                in_channels=output_channels * input_channels,
+                out_channels=(output_channels // 2) * input_channels,
                 kernel_size=3,
             )
         )
         self.conv4 = spectral_norm(
             conv2d(
-                input_channels=output_channels * 2 * input_channels,
-                output_channels=output_channels * input_channels,
+                in_channels=output_channels * 2 * input_channels,
+                out_channels=output_channels * input_channels,
                 kernel_size=3,
             )
         )

--- a/satflow/models/gan/discriminators.py
+++ b/satflow/models/gan/discriminators.py
@@ -368,9 +368,7 @@ class NowcastingTemporalDiscriminator(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.transform(x)
-        print(x.shape)
         x = self.space2depth(x)
-        print(x.shape)
         # Have to move time and channels
         x = torch.permute(x, dims=(0, 2, 1, 3, 4))
         x = self.d1(x)

--- a/satflow/models/gan/discriminators.py
+++ b/satflow/models/gan/discriminators.py
@@ -368,9 +368,15 @@ class NowcastingTemporalDiscriminator(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.transform(x)
+        print(x.shape)
         x = self.space2depth(x)
+        print(x.shape)
+        # Have to move time and channels
+        x = torch.permute(x, dims=(0, 2, 1, 3, 4))
         x = self.d1(x)
         x = self.d2(x)
+        # Convert back to T x C x H x W
+        x = torch.permute(x, dims=(0, 2, 1, 3, 4))
         # Per Timestep part now, same as spatial discriminator
         representations = []
         for idx in range(x.size(1)):

--- a/satflow/models/gan/discriminators.py
+++ b/satflow/models/gan/discriminators.py
@@ -363,7 +363,7 @@ class NowcastingTemporalDiscriminator(torch.nn.Module):
             conv_type=conv_type,
         )
 
-        self.fc = spectral_norm(torch.nn.Linear(2 * internal_chn * input_channels, 2))
+        self.fc = spectral_norm(torch.nn.Linear(2 * internal_chn * input_channels, 1))
         self.relu = torch.nn.ReLU()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -385,12 +385,12 @@ class NowcastingTemporalDiscriminator(torch.nn.Module):
             rep = self.d_last(rep)
             # Sum-pool along width and height all 8 representations, pretty sure only the last output
             rep = torch.sum(rep.view(rep.size(0), rep.size(1), -1), dim=2)
-            rep = self.fc(rep)
             representations.append(rep)
         # The representations are summed together before the ReLU
         x = torch.stack(representations, dim=0).sum(dim=0)  # Should be right shape? TODO Check
         # ReLU the output
-        x = self.relu(x)
+        x = self.fc(x)
+        # x = self.relu(x)
         return x
 
 
@@ -442,7 +442,7 @@ class NowcastingSpatialDiscriminator(torch.nn.Module):
         )
 
         # Spectrally normalized linear layer for binary classification
-        self.fc = spectral_norm(torch.nn.Linear(2 * internal_chn * input_channels, 2))
+        self.fc = spectral_norm(torch.nn.Linear(2 * internal_chn * input_channels, 1))
         self.relu = torch.nn.ReLU()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -460,11 +460,11 @@ class NowcastingSpatialDiscriminator(torch.nn.Module):
 
             # Sum-pool along width and height all 8 representations, pretty sure only the last output
             rep = torch.sum(rep.view(rep.size(0), rep.size(1), -1), dim=2)
-            rep = self.fc(rep)
             representations.append(rep)
 
         # The representations are summed together before the ReLU
         x = torch.stack(representations, dim=0).sum(dim=0)  # Should be right shape? TODO Check
         # ReLU the output
-        x = self.relu(x)
+        x = self.fc(x)
+        # x = self.relu(x)
         return x

--- a/satflow/models/gan/discriminators.py
+++ b/satflow/models/gan/discriminators.py
@@ -308,3 +308,19 @@ class CloudGANDiscriminator(nn.Module):
         x = self.flatten(x)
         x = self.fc(x)
         return x
+
+
+class NowcastingTemporalDiscriminator(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        pass
+
+
+class NowcastingSpatialDiscriminator(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        pass

--- a/satflow/models/gan/discriminators.py
+++ b/satflow/models/gan/discriminators.py
@@ -338,6 +338,7 @@ class NowcastingTemporalDiscriminator(torch.nn.Module):
         x = self.d4(x)
         x = self.d5(x)
         x = self.d6(x)
+        x = torch.sum(x.view(x.size(0), x.size(1), -1), dim=2)  # Sum pool
         x = self.fc(x)
         return torch.nn.ReLU(x)
 

--- a/satflow/models/gan/generators.py
+++ b/satflow/models/gan/generators.py
@@ -459,7 +459,6 @@ class NowcastingSampler(torch.nn.Module):
         self.convGRU1 = ConvGRU(
             input_dim=latent_channels, hidden_dim=context_channels, kernel_size=(3, 3), n_layers=1
         )
-        print(f" G1 Latent Input: {latent_channels} Output: {latent_channels // 2}")
         self.g1 = GBlock(input_channels=latent_channels, output_channels=latent_channels // 2)
         self.convGRU2 = ConvGRU(
             input_dim=latent_channels // 2,
@@ -516,7 +515,7 @@ class NowcastingSampler(torch.nn.Module):
 
     def forward(
         self, conditioning_states: List[torch.Tensor], latent_dim: torch.Tensor
-    ) -> List[torch.Tensor]:
+    ) -> torch.Tensor:
         """
         Perform the sampling from Skillful Nowcasting with GANs
         Args:
@@ -546,9 +545,6 @@ class NowcastingSampler(torch.nn.Module):
             init_states[3] = recurrent_state
             # Reduce to 4D input
             x = torch.squeeze(x, dim=0)
-            print(
-                f"Latent Dim: {latent_dim.shape}, X: {x.shape}, Reccurent: {recurrent_state.shape}"
-            )
             # GBlock1
             x = self.stacks[f"forecast_{i}"][1](x)
             # Expand to 5D input
@@ -590,4 +586,6 @@ class NowcastingSampler(torch.nn.Module):
             # Depth2Space
             x = self.stacks[f"forecast_{i}"][11](x)
             forecasts.append(x)
+        # Convert forecasts to a torch Tensor
+        forecasts = torch.cat(forecasts, dim=0)
         return forecasts

--- a/satflow/models/gan/generators.py
+++ b/satflow/models/gan/generators.py
@@ -499,22 +499,31 @@ class NowcastingSampler(torch.nn.Module):
         # Iterate through each forecast step
         # Initialize with conditioning state for first one, output for second one
         forecasts = []
+        init_states = conditioning_states
         for i in range(self.forecast_steps):
             # Start at lowest one and go up, conditioning states
             # ConvGRU1
-            x = self.stacks[f"forecast_{i}"][0](latent_dim, hidden_state=conditioning_states[3])
+            x = self.stacks[f"forecast_{i}"][0](latent_dim, hidden_state=init_states[3])
+            # Update for next timestep
+            init_states[3] = x
             # GBlock1
             x = self.stacks[f"forecast_{i}"][1](x)
             # ConvGRU2
-            x = self.stacks[f"forecast_{i}"][2](x, hidden_state=conditioning_states[2])
+            x = self.stacks[f"forecast_{i}"][2](x, hidden_state=init_states[2])
+            # Update for next timestep
+            init_states[2] = x
             # GBlock2
             x = self.stacks[f"forecast_{i}"][3](x)
             # ConvGRU3
-            x = self.stacks[f"forecast_{i}"][4](x, hidden_state=conditioning_states[1])
+            x = self.stacks[f"forecast_{i}"][4](x, hidden_state=init_states[1])
+            # Update for next timestep
+            init_states[1] = x
             # GBlock3
             x = self.stacks[f"forecast_{i}"][5](x)
             # ConvGRU4
-            x = self.stacks[f"forecast_{i}"][6](x, hidden_state=conditioning_states[0])
+            x = self.stacks[f"forecast_{i}"][6](x, hidden_state=init_states[0])
+            # Update for next timestep
+            init_states[0] = x
             # GBlock4
             x = self.stacks[f"forecast_{i}"][7](x)
             # Depth2Space

--- a/satflow/models/layers/Attention.py
+++ b/satflow/models/layers/Attention.py
@@ -176,6 +176,59 @@ class SelfAttention(nn.Module):
         return out
 
 
+class SelfAttention2d(nn.Module):
+    r"""Self Attention Module as proposed in the paper `"Self-Attention Generative Adversarial
+    Networks by Han Zhang et. al." <https://arxiv.org/abs/1805.08318>`_
+    .. math:: attention = softmax((query(x))^T * key(x))
+    .. math:: output = \gamma * value(x) * attention + x
+    where
+    - :math:`query` : 2D Convolution Operation
+    - :math:`key` : 2D Convolution Operation
+    - :math:`value` : 2D Convolution Operation
+    - :math:`x` : Input
+    Args:
+        input_dims (int): The input channel dimension in the input ``x``.
+        output_dims (int, optional): The output channel dimension. If ``None`` the output
+            channel value is computed as ``input_dims // 8``. So if the ``input_dims`` is **less
+            than 8** then the layer will give an error.
+        return_attn (bool, optional): Set it to ``True`` if you want the attention values to be
+            returned.
+    """
+
+    def __init__(self, input_dims, output_dims=None, return_attn=False):
+        output_dims = input_dims // 8 if output_dims is None else output_dims
+        if output_dims == 0:
+            raise Exception(
+                "The output dims corresponding to the input dims is 0. Increase the input\
+                            dims to 8 or more. Else specify output_dims"
+            )
+        super(SelfAttention2d, self).__init__()
+        self.query = nn.Conv2d(input_dims, output_dims, 1)
+        self.key = nn.Conv2d(input_dims, output_dims, 1)
+        self.value = nn.Conv2d(input_dims, input_dims, 1)
+        self.gamma = nn.Parameter(torch.zeros(1))
+        self.return_attn = return_attn
+
+    def forward(self, x):
+        r"""Computes the output of the Self Attention Layer
+        Args:
+            x (torch.Tensor): A 4D Tensor with the channel dimension same as ``input_dims``.
+        Returns:
+            A tuple of the ``output`` and the ``attention`` if ``return_attn`` is set to ``True``
+            else just the ``output`` tensor.
+        """
+        dims = (x.size(0), -1, x.size(2) * x.size(3))
+        out_query = self.query(x).view(dims)
+        out_key = self.key(x).view(dims).permute(0, 2, 1)
+        attn = F.softmax(torch.bmm(out_key, out_query), dim=-1)
+        out_value = self.value(x).view(dims)
+        out_value = torch.bmm(out_value, attn).view(x.size())
+        out = self.gamma * out_value + x
+        if self.return_attn:
+            return out, attn
+        return out
+
+
 if __name__ == "__main__":
 
     self_attn = SelfAttention(16)  # no less than 8

--- a/satflow/models/layers/ConvGRU.py
+++ b/satflow/models/layers/ConvGRU.py
@@ -68,7 +68,8 @@ class ConvGRUCell(nn.Module):
         # init hidden on forward
         if h_prev is None:
             h_prev = self.init_hidden(input)
-
+        print(h_prev.shape)
+        print(input.shape)
         combined = torch.cat((input, h_prev), dim=1)  # concatenate along channel axis
 
         combined_conv = F.sigmoid(self.conv_zr(combined))

--- a/satflow/models/layers/ConvGRU.py
+++ b/satflow/models/layers/ConvGRU.py
@@ -68,8 +68,6 @@ class ConvGRUCell(nn.Module):
         # init hidden on forward
         if h_prev is None:
             h_prev = self.init_hidden(input)
-        print(h_prev.shape)
-        print(input.shape)
         combined = torch.cat((input, h_prev), dim=1)  # concatenate along channel axis
 
         combined_conv = F.sigmoid(self.conv_zr(combined))

--- a/satflow/models/layers/ConvGRU.py
+++ b/satflow/models/layers/ConvGRU.py
@@ -1,247 +1,344 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
+import torch.nn.init as init
+import torch.nn.functional as functional
+from typing import Union, List, Tuple
+
+# ------------------------------------------------------------------------------
+# One-dimensional Convolution Gated Recurrent Unit
+# ------------------------------------------------------------------------------
 
 
-class ConvGRUCell(nn.Module):
+class ConvGRU1DCell(nn.Module):
+
+    # --------------------------------------------------------------------------
+    # Initialization
+    # --------------------------------------------------------------------------
+
     def __init__(
         self,
-        input_dim,
-        hidden_dim,
-        kernel_size=(3, 3),
-        bias=True,
-        activation=F.tanh,
-        batchnorm=False,
+        input_channels: int,
+        hidden_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        padding: int = 0,
+        recurrent_kernel_size: int = 3,
     ):
         """
-        Initialize ConvGRU cell.
-        Parameters
-        ----------
-        input_dim: int
-            Number of channels of input tensor.
-        hidden_dim: int
-            Number of channels of hidden state.
-        kernel_size: (int, int)
-            Size of the convolutional kernel.
-        bias: bool
-            Whether or not to add the bias.
+        One-Dimensional Convolutional Gated Recurrent Unit (ConvGRU1D) cell.
+
+        The input-to-hidden convolution kernel can be defined arbitrarily using
+        the kernel_size, stride and padding parameters. The hidden-to-hidden
+        convolution kernel is forced to be unit-stride, with a padding assuming
+        an odd kernel size, in order to keep the number of features the same.
+
+        The hidden state is initialized by default to a zero tensor of the
+        appropriate shape.
+
+        Arguments:
+            input_channels {int} -- [Number of channels of the input tensor]
+            hidden_channels {int} -- [Number of channels of the hidden state]
+            kernel_size {int} -- [Size of the input-to-hidden convolving kernel]
+
+        Keyword Arguments:
+            stride {int} -- [Stride of the input-to-hidden convolution]
+                             (default: {1})
+            padding {int} -- [Zero-padding added to both sides of the input]
+                              (default: {0})
+            recurrent_kernel_size {int} -- [Size of the hidden-to-hidden
+                                            convolving kernel] (default: {3})
         """
-        super().__init__()
-        self.input_dim = input_dim
-        self.hidden_dim = hidden_dim
-
-        self.kernel_size = (
-            kernel_size if isinstance(kernel_size, (tuple, list)) else [kernel_size] * 2
+        super(ConvGRU1DCell, self).__init__()
+        # ----------------------------------------------------------------------
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.h_channels = hidden_channels
+        self.padding_ih = padding
+        self.padding_hh = recurrent_kernel_size // 2
+        # ----------------------------------------------------------------------
+        self.weight_ih = nn.Parameter(
+            torch.ones(hidden_channels * 3, input_channels, kernel_size),
+            requires_grad=True,
         )
-        self.padding = self.kernel_size[0] // 2, self.kernel_size[1] // 2
-        self.bias = bias
-        self.activation = activation
-        self.batchnorm = batchnorm
-
-        self.conv_zr = nn.Conv2d(
-            in_channels=self.input_dim + self.hidden_dim,
-            out_channels=2 * self.hidden_dim,
-            kernel_size=self.kernel_size,
-            padding=self.padding,
-            bias=self.bias,
+        self.weight_hh = nn.Parameter(
+            torch.ones(hidden_channels * 3, input_channels, recurrent_kernel_size),
+            requires_grad=True,
         )
-
-        self.conv_h1 = nn.Conv2d(
-            in_channels=self.input_dim,
-            out_channels=self.hidden_dim,
-            kernel_size=self.kernel_size,
-            padding=self.padding,
-            bias=self.bias,
-        )
-
-        self.conv_h2 = nn.Conv2d(
-            in_channels=self.hidden_dim,
-            out_channels=self.hidden_dim,
-            kernel_size=self.kernel_size,
-            padding=self.padding,
-            bias=self.bias,
-        )
-
+        self.bias_ih = nn.Parameter(torch.zeros(hidden_channels * 3), requires_grad=True)
+        self.bias_hh = nn.Parameter(torch.zeros(hidden_channels * 3), requires_grad=True)
+        # ----------------------------------------------------------------------
         self.reset_parameters()
 
-    def forward(self, input, h_prev=None):
-        # init hidden on forward
-        if h_prev is None:
-            h_prev = self.init_hidden(input)
-        combined = torch.cat((input, h_prev), dim=1)  # concatenate along channel axis
+    def reset_parameters(self):
+        init.orthogonal_(self.weight_hh)
+        init.xavier_uniform_(self.weight_ih)
+        init.zeros_(self.bias_hh)
+        init.zeros_(self.bias_ih)
 
-        combined_conv = F.sigmoid(self.conv_zr(combined))
+    # --------------------------------------------------------------------------
+    # Processing
+    # --------------------------------------------------------------------------
 
-        z, r = torch.split(combined_conv, self.hidden_dim, dim=1)
+    def forward(self, input, hx=None):
+        output_size = (
+            int((input.size(-1) - self.kernel_size + 2 * self.padding_ih) / self.stride) + 1
+        )
+        # Handle the case of no hidden state provided
+        if hx is None:
+            hx = torch.zeros(input.size(0), self.h_channels, output_size, device=input.device)
+        # Run the optimized convgru-cell
+        return _opt_convgrucell_1d(
+            input,
+            hx,
+            self.h_channels,
+            self.weight_ih,
+            self.weight_hh,
+            self.bias_ih,
+            self.bias_hh,
+            self.stride,
+            self.padding_ih,
+            self.padding_hh,
+        )
 
-        h_ = self.activation(self.conv_h1(input) + r * self.conv_h2(h_prev))
 
-        h_cur = (1 - z) * h_ + z * h_prev
+# ------------------------------------------------------------------------------
+# Two-dimensional Convolution Gated Recurrent Unit
+# ------------------------------------------------------------------------------
 
-        return h_cur
 
-    def init_hidden(self, input):
-        bs, ch, h, w = input.shape
-        return one_param(self).new_zeros(bs, self.hidden_dim, h, w)
+class ConvGRU2DCell(nn.Module):
+
+    # --------------------------------------------------------------------------
+    # Initialization
+    # --------------------------------------------------------------------------
+
+    def __init__(
+        self,
+        input_channels: int,
+        hidden_channels: int,
+        kernel_size: Union[int, Tuple[int, int]],
+        stride: Union[int, Tuple[int, int]] = (1, 1),
+        padding: Union[int, Tuple[int, int]] = (0, 0),
+        recurrent_kernel_size: Union[int, Tuple[int, int]] = (3, 3),
+    ):
+        """
+        Two-Dimensional Convolutional Gated Recurrent Unit (ConvGRU2D) cell.
+
+        The input-to-hidden convolution kernel can be defined arbitrarily using
+        the kernel_size, stride and padding parameters. The hidden-to-hidden
+        convolution kernel is forced to be unit-stride, with a padding assuming
+        an odd kernel size in both dimensions, in order to keep the number of
+        features the same.
+
+        The hidden state is initialized by default to a zero tensor of the
+        appropriate shape.
+
+        Arguments:
+            input_channels {int} -- [Number of channels of the input tensor]
+            hidden_channels {int} -- [Number of channels of the hidden state]
+            kernel_size {int or tuple} -- [Size of the input-to-hidden
+                                           convolving kernel]
+
+        Keyword Arguments:
+            stride {int or tuple} -- [Stride of the input-to-hidden convolution]
+                                      (default: {(1, 1)})
+            padding {int or tuple} -- [Zero-padding added to both sides of the
+                                       input] (default: {0})
+            recurrent_kernel_size {int or tuple} -- [Size of the hidden-to-
+                                                     -hidden convolving kernel]
+                                                     (default: {(3, 3)})
+        """
+        super(ConvGRU2DCell, self).__init__()
+        # ----------------------------------------------------------------------
+        # Handle int to tuple conversion
+        if isinstance(recurrent_kernel_size, int):
+            recurrent_kernel_size = (recurrent_kernel_size,) * 2
+        if isinstance(kernel_size, int):
+            kernel_size = (kernel_size,) * 2
+        if isinstance(stride, int):
+            stride = (stride,) * 2
+        if isinstance(padding, int):
+            padding = (padding,) * 2
+        # ----------------------------------------------------------------------
+        # Save input parameters for later
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.h_channels = hidden_channels
+        self.padding_ih = padding
+        self.padding_hh = (
+            recurrent_kernel_size[0] // 2,
+            recurrent_kernel_size[1] // 2,
+        )
+        # ----------------------------------------------------------------------
+        # Initialize the convolution kernels
+        self.weight_ih = nn.Parameter(
+            torch.ones(
+                hidden_channels * 3,
+                input_channels,
+                kernel_size[0],
+                kernel_size[1],
+            ),
+            requires_grad=True,
+        )
+        self.weight_hh = nn.Parameter(
+            torch.ones(
+                hidden_channels * 3,
+                input_channels,
+                recurrent_kernel_size[0],
+                recurrent_kernel_size[1],
+            ),
+            requires_grad=True,
+        )
+        self.bias_ih = nn.Parameter(torch.zeros(hidden_channels * 3), requires_grad=True)
+        self.bias_hh = nn.Parameter(torch.zeros(hidden_channels * 3), requires_grad=True)
+        # ----------------------------------------------------------------------
+        self.reset_parameters()
 
     def reset_parameters(self):
-        # self.conv.reset_parameters()
-        nn.init.xavier_uniform_(self.conv_zr.weight, gain=nn.init.calculate_gain("tanh"))
-        self.conv_zr.bias.data.zero_()
-        nn.init.xavier_uniform_(self.conv_h1.weight, gain=nn.init.calculate_gain("tanh"))
-        self.conv_h1.bias.data.zero_()
-        nn.init.xavier_uniform_(self.conv_h2.weight, gain=nn.init.calculate_gain("tanh"))
-        self.conv_h2.bias.data.zero_()
+        init.orthogonal_(self.weight_hh)
+        init.xavier_uniform_(self.weight_ih)
+        init.zeros_(self.bias_hh)
+        init.zeros_(self.bias_ih)
 
-        if self.batchnorm:
-            self.bn1.reset_parameters()
-            self.bn2.reset_parameters()
+    # --------------------------------------------------------------------------
+    # Processing
+    # --------------------------------------------------------------------------
 
-
-def one_param(m):
-    "First parameter in `m`"
-    return next(m.parameters())
-
-
-def dropout_mask(x, sz, p):
-    "Return a dropout mask of the same type as `x`, size `sz`, with probability `p` to cancel an element."
-    return x.new_empty(*sz).bernoulli_(1 - p).div_(1 - p)
-
-
-class RNNDropout(nn.Module):
-    "Dropout with probability `p` that is consistent on the seq_len dimension."
-
-    def __init__(self, p=0.5):
-        super().__init__()
-        self.p = p
-
-    def forward(self, x):
-        if not self.training or self.p == 0.0:
-            return x
-        return x * dropout_mask(x.data, (x.size(0), 1, *x.shape[2:]), self.p)
+    def forward(self, input, hx=None):
+        output_size = (
+            int((input.size(-2) - self.kernel_size[0] + 2 * self.padding_ih[0]) / self.stride[0])
+            + 1,
+            int((input.size(-1) - self.kernel_size[1] + 2 * self.padding_ih[1]) / self.stride[1])
+            + 1,
+        )
+        # Handle the case of no hidden state provided
+        if hx is None:
+            hx = torch.zeros(input.size(0), self.h_channels, *output_size, device=input.device)
+        # Run the optimized convgru-cell
+        return _opt_convgrucell_2d(
+            input,
+            hx,
+            self.h_channels,
+            self.weight_ih,
+            self.weight_hh,
+            self.bias_ih,
+            self.bias_hh,
+            self.stride,
+            self.padding_ih,
+            self.padding_hh,
+        )
 
 
 class ConvGRU(nn.Module):
     def __init__(
         self,
-        input_dim,
-        hidden_dim,
-        kernel_size,
-        n_layers,
-        batch_first=True,
-        bias=True,
-        activation=F.tanh,
-        input_p=0.2,
-        hidden_p=0.1,
-        batchnorm=False,
+        input_channels: int,
+        hidden_channels: int,
+        kernel_size: Union[int, Tuple[int, int]],
+        stride: Union[int, Tuple[int, int]] = (1, 1),
+        padding: Union[int, Tuple[int, int]] = (0, 0),
+        recurrent_kernel_size: Union[int, Tuple[int, int]] = (3, 3),
     ):
+        """
+        Recurrent wrapper for use with any rnn cell that takes as input a tensor
+        and a hidden state and returns an updated hidden state. This wrapper
+        returns the full sequence of hidden states. It assumes the first
+        dimension corresponds to the timesteps, and that the other dimensions
+        are directly compatible with the given rnn cell.
+        Implements a very basic truncated backpropagation through time
+        corresponding to the case k1=k2 (see 'An Efficient Gradient-Based
+        Algorithm for On-Line Training of Recurrent Network Trajectories',
+        Ronald J. Williams and Jing Pen, Neural Computation, vol. 2,
+        pp. 490-501, 1990).
+        Args:
+            rnn_cell (nn.Module): [The torch module that takes one timestep of
+                the input tensor and the hidden state and returns a new hidden
+                state]
+            truncation_steps (int, optional): [The maximum number of timesteps
+                to include in the backpropagation graph. This can help speed up
+                runtime on CPU and avoid vanishing gradient problems, however
+                it is mostly useful for very long sequences]. Defaults to None.
+        """
         super(ConvGRU, self).__init__()
 
-        self._check_kernel_size_consistency(kernel_size)
-
-        # Make sure that both `kernel_size` and `hidden_dim` are lists having len == num_layers
-        kernel_size = self._extend_for_multilayer(kernel_size, n_layers)
-        hidden_dim = self._extend_for_multilayer(hidden_dim, n_layers)
-        activation = self._extend_for_multilayer(activation, n_layers)
-
-        if not len(kernel_size) == len(hidden_dim) == len(activation) == n_layers:
-            raise ValueError("Inconsistent list length.")
-
-        self.input_dim = input_dim
-        self.hidden_dim = hidden_dim
-        self.kernel_size = kernel_size
-        self.n_layers = n_layers
-        self.batch_first = batch_first
-        self.bias = bias
-        self.input_p = input_p
-        self.hidden_p = hidden_p
-
-        cell_list = []
-        for i in range(self.n_layers):
-            cur_input_dim = self.input_dim if i == 0 else self.hidden_dim[i - 1]
-
-            cell_list.append(
-                ConvGRUCell(
-                    input_dim=cur_input_dim,
-                    hidden_dim=self.hidden_dim[i],
-                    kernel_size=self.kernel_size[i],
-                    bias=self.bias,
-                    activation=activation[i],
-                    batchnorm=batchnorm,
-                )
-            )
-
-        self.cell_list = nn.ModuleList(cell_list)
-        self.input_dp = RNNDropout(input_p)
-        self.hidden_dps = nn.ModuleList([nn.Dropout(hidden_p) for l in range(n_layers)])
-        self.reset_parameters()
-
-    def __repr__(self):
-        s = f"ConvGru(in={self.input_dim}, out={self.hidden_dim[0]}, ks={self.kernel_size[0]}, "
-        s += f"n_layers={self.n_layers}, input_p={self.input_p}, hidden_p={self.hidden_p})"
-        return s
+        self.rnn_cell = ConvGRU2DCell(
+            input_channels, hidden_channels, kernel_size, stride, padding, recurrent_kernel_size
+        )
 
     def forward(self, input, hidden_state=None):
-        """
-        Parameters
-        ----------
-        input_tensor:
-            5-D Tensor either of shape (t, b, c, h, w) or (b, t, c, h, w)
-        hidden_state:
-        Returns
-        -------
-        last_state_list, layer_output
-        """
-        input = self.input_dp(input)
-        cur_layer_input = torch.unbind(input, dim=int(self.batch_first))
+        output = []
+        for step in range(input.size(1)):
+            # Compute current time-step
+            hidden_state = self.rnn_cell(input[:, step, :, :, :], hidden_state)
+            output.append(hidden_state)
+        # Stack the list of output hidden states into a tensor
+        output = torch.stack(output, 0)
+        return output
 
-        if hidden_state is None:
-            hidden_state = self.get_init_states(cur_layer_input[0])
 
-        seq_len = len(cur_layer_input)
+# --------------------------------------------------------------------------
+# Torchscript optimized cell functions
+# --------------------------------------------------------------------------
 
-        layer_output_list = []
-        last_state_list = []
 
-        for l, (gru_cell, hid_dp) in enumerate(zip(self.cell_list, self.hidden_dps)):
-            h = hidden_state[l]
-            output_inner = []
-            for t in range(seq_len):
-                h = gru_cell(input=cur_layer_input[t], h_prev=h)
-                output_inner.append(h)
+@torch.jit.script
+def _opt_cell_end(hidden, ih_1, hh_1, ih_2, hh_2, ih_3, hh_3):
+    z = torch.sigmoid(ih_1 + hh_1)
+    r = torch.sigmoid(ih_2 + hh_2)
+    n = torch.tanh(ih_3 + r * hh_3)
+    out = (1 - z) * n + z * hidden
+    return out
 
-            cur_layer_input = torch.stack(output_inner)  # list to array
-            if l != self.n_layers:
-                cur_layer_input = hid_dp(cur_layer_input)
-            last_state_list.append(h)
 
-        layer_output = torch.stack(output_inner, dim=int(self.batch_first))
-        last_state_list = torch.stack(last_state_list, dim=0)
-        return layer_output, last_state_list
+@torch.jit.script
+def _opt_convgrucell_1d(
+    inputs,
+    hidden,
+    channels: int,
+    w_ih,
+    w_hh,
+    b_ih,
+    b_hh,
+    stride: int,
+    pad1: int,
+    pad2: int,
+):
+    ih_output = functional.conv1d(inputs, w_ih, bias=b_ih, stride=stride, padding=pad1)
+    hh_output = functional.conv1d(hidden, w_hh, bias=b_hh, stride=1, padding=pad2)
+    output = _opt_cell_end(
+        hidden,
+        torch.narrow(ih_output, 1, 0, channels),
+        torch.narrow(hh_output, 1, 0, channels),
+        torch.narrow(ih_output, 1, channels, channels),
+        torch.narrow(hh_output, 1, channels, channels),
+        torch.narrow(ih_output, 1, 2 * channels, channels),
+        torch.narrow(hh_output, 1, 2 * channels, channels),
+    )
+    return output
 
-    def reset_parameters(self):
-        for c in self.cell_list:
-            c.reset_parameters()
 
-    def get_init_states(self, input):
-        init_states = []
-        for gru_cell in self.cell_list:
-            init_states.append(gru_cell.init_hidden(input))
-        return init_states
-
-    @staticmethod
-    def _check_kernel_size_consistency(kernel_size):
-        if not (
-            isinstance(kernel_size, tuple)
-            or (
-                isinstance(kernel_size, list)
-                and all([isinstance(elem, tuple) for elem in kernel_size])
-            )
-        ):
-            raise ValueError("`kernel_size` must be tuple or list of tuples")
-
-    @staticmethod
-    def _extend_for_multilayer(param, num_layers):
-        if not isinstance(param, list):
-            param = [param] * num_layers
-        return param
+@torch.jit.script
+def _opt_convgrucell_2d(
+    inputs,
+    hidden,
+    channels: int,
+    w_ih,
+    w_hh,
+    b_ih,
+    b_hh,
+    stride: List[int],
+    pad1: List[int],
+    pad2: List[int],
+):
+    ih_output = functional.conv2d(inputs, w_ih, bias=b_ih, stride=stride, padding=pad1)
+    hh_output = functional.conv2d(hidden, w_hh, bias=b_hh, stride=1, padding=pad2)
+    output = _opt_cell_end(
+        hidden,
+        torch.narrow(ih_output, 1, 0, channels),
+        torch.narrow(hh_output, 1, 0, channels),
+        torch.narrow(ih_output, 1, channels, channels),
+        torch.narrow(hh_output, 1, channels, channels),
+        torch.narrow(ih_output, 1, 2 * channels, channels),
+        torch.narrow(hh_output, 1, 2 * channels, channels),
+    )
+    return output

--- a/satflow/models/layers/__init__.py
+++ b/satflow/models/layers/__init__.py
@@ -4,3 +4,4 @@ from .ConvLSTM import ConvLSTMCell
 from .SpatioTemporalLSTMCell_memory_decoupling import SpatioTemporalLSTMCell
 from .RUnetLayers import Recurrent_block, RRCNN_block
 from .ConditionTime import ConditionTime
+from .Attention import SelfAttention, SelfAttention2d

--- a/satflow/models/losses.py
+++ b/satflow/models/losses.py
@@ -48,7 +48,9 @@ class GridCellLoss(nn.Module):
         if self.weight_fn is not None:
             difference *= self.weight_fn(targets)
         difference /= targets.size(1) * targets.size(3) * targets.size(4)  # 1/HWN
-        return difference
+        return torch.mean(
+            torch.mean(torch.mean(difference, dim=-1), dim=-1), dim=1
+        )  # Mean of Time/Width/Height
 
 
 class NowcastingLoss(nn.Module):
@@ -107,7 +109,6 @@ class FocalLoss(nn.Module):
             logit = logit.view(-1, logit.size(-1))
         target = torch.squeeze(target, 1)
         target = target.view(-1, 1)
-        # print(logit.shape, target.shape)
         #
         alpha = self.alpha
 

--- a/satflow/models/losses.py
+++ b/satflow/models/losses.py
@@ -57,8 +57,10 @@ class NowcastingLoss(nn.Module):
     def __init__(self):
         super().__init__()
 
-    def forward(self, real_loss, fake_loss):
-        return F.relu(1.0 - real_loss) + F.relu(1.0 + fake_loss)
+    def forward(self, x, real_flag):
+        if real_flag is True:
+            x = -x
+        return F.relu(1.0 + x).mean()
 
 
 class FocalLoss(nn.Module):

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -68,10 +68,12 @@ class NowcastingGAN(pl.LightningModule):
         )
         self.latent_stack = LatentConditioningStack(
             shape=(8 * self.input_channels, output_shape // 32, output_shape // 32),
-            output_channels=self.latent_channels,
+            output_channels=768,
         )
         self.sampler = NowcastingSampler(
-            forecast_steps=forecast_steps, input_channels=self.latent_channels
+            forecast_steps=forecast_steps,
+            latent_channels=768,
+            context_channels=self.latent_channels,
         )
         self.generator = NowcastingGenerator(
             self.conditioning_stack, self.latent_stack, self.sampler

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -49,7 +49,8 @@ class NowcastingGAN(pl.LightningModule):
             num_samples: Number of samples of the latent space to sample for training/validation
             grid_lambda: Lambda for the grid regularization loss
             output_shape: Shape of the output predictions, generally should be same as the input shape
-            latent_channels: Number of channels that the latent space should be reshaped to, input dimension into ConvGRU, also affects the number of channels for other linked inputs/outputs
+            latent_channels: Number of channels that the latent space should be reshaped to,
+            input dimension into ConvGRU, also affects the number of channels for other linked inputs/outputs
             pretrained:
         """
         super(NowcastingGAN, self).__init__()

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -1,11 +1,17 @@
 import torch
 import torch.nn.functional as F
 from typing import Union
-from satflow.models.losses import FocalLoss
+from satflow.models.losses import FocalLoss, get_loss
 import numpy as np
 import pytorch_lightning as pl
 
 from satflow.models.base import register_model
+from satflow.models.gan.common import LatentConditioningStack, ContextConditioningStack
+from satflow.models.gan.generators import NowcastingSampler
+from satflow.models.gan.discriminators import (
+    NowcastingSpatialDiscriminator,
+    NowcastingTemporalDiscriminator,
+)
 
 
 @register_model
@@ -38,15 +44,7 @@ class NowcastingGAN(pl.LightningModule):
         """
         super(NowcastingGAN, self).__init__()
         self.lr = lr
-        assert loss in ["mse", "bce", "binary_crossentropy", "crossentropy", "focal"]
-        if loss == "mse":
-            self.criterion = F.mse_loss
-        elif loss in ["bce", "binary_crossentropy", "crossentropy"]:
-            self.criterion = F.nll_loss
-        elif loss in ["focal"]:
-            self.criterion = FocalLoss()
-        else:
-            raise ValueError(f"loss {loss} not recognized")
+        self.criterion = get_loss(loss)
         self.make_vis = make_vis
         self.input_channels = input_channels
         self.model = NowcastingGAN(
@@ -98,41 +96,3 @@ class NowcastingGAN(pl.LightningModule):
         y_hat = self(x)
         loss = self.criterion(y_hat, y)
         return loss
-
-
-class NowcastingModel(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    def forward(self, x):
-        pass
-
-    def temporal_discriminator(self):
-        pass
-
-    def spatial_discriminator(self):
-        pass
-
-    def latent_conditioning_stack(self):
-        pass
-
-    def generator(self):
-        pass
-
-    def space_to_dim(self):
-        pass
-
-    def dim_to_space(self):
-        pass
-
-    def g_block(self):
-        pass
-
-    def d_block(self):
-        pass
-
-    def d3_block(self):
-        pass
-
-    def l_block(self):
-        pass

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -50,7 +50,7 @@ class NowcastingGAN(pl.LightningModule):
             grid_lambda: Lambda for the grid regularization loss
             output_shape: Shape of the output predictions, generally should be same as the input shape
             latent_channels: Number of channels that the latent space should be reshaped to,
-            input dimension into ConvGRU, also affects the number of channels for other linked inputs/outputs
+                input dimension into ConvGRU, also affects the number of channels for other linked inputs/outputs
             pretrained:
         """
         super(NowcastingGAN, self).__init__()

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -30,6 +30,7 @@ class NowcastingGAN(pl.LightningModule):
         beta1: float = 0.0,
         beta2: float = 0.999,
         latent_channels: int = 768,
+        context_channels: int = 384,
     ):
         """
         Nowcasting GAN is an attempt to recreate DeepMind's Skillful Nowcasting GAN from https://arxiv.org/abs/2104.00954
@@ -61,20 +62,21 @@ class NowcastingGAN(pl.LightningModule):
         self.num_samples = num_samples
         self.visualize = visualize
         self.latent_channels = latent_channels
+        self.context_channels = context_channels
         self.input_channels = input_channels
         self.conditioning_stack = ContextConditioningStack(
             input_channels=input_channels,
             conv_type=conv_type,
-            output_channels=self.latent_channels,
+            output_channels=self.context_channels,
         )
         self.latent_stack = LatentConditioningStack(
             shape=(8 * self.input_channels, output_shape // 32, output_shape // 32),
-            output_channels=768,
+            output_channels=self.latent_channels,
         )
         self.sampler = NowcastingSampler(
             forecast_steps=forecast_steps,
-            latent_channels=768,
-            context_channels=self.latent_channels,
+            latent_channels=self.latent_channels,
+            context_channels=self.context_channels,
         )
         self.generator = NowcastingGenerator(
             self.conditioning_stack, self.latent_stack, self.sampler

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -3,7 +3,7 @@ import torch.nn.functional as F
 from torch.optim import lr_scheduler
 from typing import Union
 from collections import OrderedDict
-from satflow.models.losses import get_loss
+from satflow.models.losses import get_loss, NowcastingLoss, GridCellLoss
 import numpy as np
 import pytorch_lightning as pl
 
@@ -25,11 +25,16 @@ class NowcastingGAN(pl.LightningModule):
         output_shape: int = 256,
         hidden_dim: int = 64,
         bilinear: bool = False,
-        lr: float = 0.001,
+        gen_lr: float = 0.00005,
+        disc_lr: float = 0.0002,
         make_vis: bool = False,
         loss: Union[str, torch.nn.Module] = "mse",
         pretrained: bool = False,
         conv_type: str = "standard",
+        num_samples: int = 6,
+        grid_lambda: float = 20.0,
+        beta1: float = 0.0,
+        beta2: float = 0.999,
     ):
         """
         Nowcasting GAN is an attempt to recreate DeepMind's Skillful Nowcasting GAN from https://arxiv.org/abs/2104.00954
@@ -46,8 +51,15 @@ class NowcastingGAN(pl.LightningModule):
             pretrained:
         """
         super(NowcastingGAN, self).__init__()
-        self.lr = lr
+        self.gen_lr = gen_lr
+        self.disc_lr = disc_lr
+        self.beta1 = beta1
+        self.beta2 = beta2
         self.criterion = get_loss(loss)
+        self.discriminator_loss = NowcastingLoss()
+        self.grid_regularizer = GridCellLoss()
+        self.grid_lambda = grid_lambda
+        self.num_samples = num_samples
         self.make_vis = make_vis
         self.input_channels = input_channels
         self.conditioning_stack = ContextConditioningStack(
@@ -83,20 +95,36 @@ class NowcastingGAN(pl.LightningModule):
         return x
 
     def training_step(self, batch, batch_idx, optimizer_idx):
-        images, future_images, future_masks = batch
+        images, future_images = batch
         # train generator
         if optimizer_idx == 0:
             # generate images
             generated_images = self(images)
-            fake = torch.cat((images, generated_images), 1)
             # log sampled images
             # if np.random.random() < 0.01:
             self.visualize_step(images, future_images, generated_images, batch_idx, step="train")
 
-            # adversarial loss is binary cross-entropy
-            gan_loss = self.criterionGAN(self.discriminator(fake), True)
-            l1_loss = self.criterionL1(generated_images, future_images) * self.lambda_l1
-            g_loss = gan_loss + l1_loss
+            # First get the 6 samples to mean?
+            # TODO Make sure this is what the paper actually means, or is it run it 6 times then average output?
+            mean_prediction = []
+            for _ in range(self.num_samples):
+                mean_prediction.append(self(images))
+            mean_prediction = torch.mean(torch.cat(mean_prediction, dim=0), dim=0)
+
+            # Get Spatial Loss
+            spatial_real = self.spatial_discriminator(torch.cat((images, future_images), 1))
+            spatial_fake = self.spatial_discriminator(torch.cat((images, mean_prediction), 1))
+            spatial_loss = self.discriminator_loss(spatial_real, spatial_fake)
+
+            # Get Temporal Loss
+            temporal_real = self.temporal_discriminator(torch.cat((images, future_images), 1))
+            temporal_fake = self.temporal_discriminator(torch.cat((images, mean_prediction), 1))
+            temporal_loss = self.discriminator_loss(temporal_real, temporal_fake)
+
+            # Grid Cell Loss
+            grid_loss = self.grid_regularizer(mean_prediction, future_images)
+
+            g_loss = spatial_loss + temporal_loss - (self.grid_lambda * grid_loss)
             tqdm_dict = {"g_loss": g_loss}
             output = OrderedDict({"loss": g_loss, "progress_bar": tqdm_dict, "log": tqdm_dict})
             self.log_dict({"train/g_loss": g_loss})
@@ -106,24 +134,38 @@ class NowcastingGAN(pl.LightningModule):
         if optimizer_idx == 1:
             # Measure discriminator's ability to classify real from generated samples
 
-            # how well can it label as real?
-            real = torch.cat((images, future_images), 1)
-            real_loss = self.criterionGAN(self.discriminator(real), True)
+            # First get the 6 samples to mean?
+            # TODO Make sure this is what the paper actually means, or is it run it 6 times then average output?
+            mean_prediction = []
+            for _ in range(self.num_samples):
+                mean_prediction.append(self(images))
+            mean_prediction = torch.mean(torch.cat(mean_prediction, dim=0), dim=0)
 
-            # how well can it label as fake?
-            gen_output = self(images)
-            fake = torch.cat((images, gen_output), 1)
-            fake_loss = self.criterionGAN(self.discriminator(fake), True)
+            # Get Spatial Loss
+            spatial_real = self.spatial_discriminator(torch.cat((images, future_images), 1))
+            spatial_fake = self.spatial_discriminator(torch.cat((images, mean_prediction), 1))
+            spatial_loss = self.discriminator_loss(spatial_real, spatial_fake)
+
+            # Get Temporal Loss
+            temporal_real = self.temporal_discriminator(torch.cat((images, future_images), 1))
+            temporal_fake = self.temporal_discriminator(torch.cat((images, mean_prediction), 1))
+            temporal_loss = self.discriminator_loss(temporal_real, temporal_fake)
 
             # discriminator loss is the average of these
-            d_loss = (real_loss + fake_loss) / 2
+            d_loss = spatial_loss + temporal_loss
             tqdm_dict = {"d_loss": d_loss}
             output = OrderedDict({"loss": d_loss, "progress_bar": tqdm_dict, "log": tqdm_dict})
-            self.log_dict({"train/d_loss": d_loss})
+            self.log_dict(
+                {
+                    "train/d_loss": d_loss,
+                    "train/temporal_loss": temporal_loss,
+                    "train/spatial_loss": spatial_loss,
+                }
+            )
             return output
 
     def validation_step(self, batch, batch_idx):
-        images, future_images, future_masks = batch
+        images, future_images = batch
         # generate images
         generated_images = self(images)
         fake = torch.cat((images, generated_images), 1)
@@ -157,12 +199,11 @@ class NowcastingGAN(pl.LightningModule):
         return output
 
     def configure_optimizers(self):
-        lr = self.lr
         b1 = self.b1
         b2 = self.b2
 
-        opt_g = torch.optim.Adam(self.generator.parameters(), lr=lr, betas=(b1, b2))
-        opt_d = torch.optim.Adam(self.discriminator.parameters(), lr=lr, betas=(b1, b2))
+        opt_g = torch.optim.Adam(self.generator.parameters(), lr=self.gen_lr, betas=(b1, b2))
+        opt_d = torch.optim.Adam(self.discriminator.parameters(), lr=self.disc_lr, betas=(b1, b2))
         if self.lr_method == "plateau":
             g_scheduler = lr_scheduler.ReduceLROnPlateau(
                 opt_g, mode="min", factor=0.2, threshold=0.01, patience=10

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -198,9 +198,7 @@ class NowcastingGAN(pl.LightningModule):
         for _ in range(self.num_samples):
             mean_prediction.append(self(images))
         # It is a list of tensors of forecasts
-        print(f"Prediction Forecast: {mean_prediction[0].shape}")
         mean_prediction = self.average_tensors(mean_prediction)
-        print(f"Mean Prediction: {mean_prediction.shape}")
 
         # Get Spatial Loss
         spatial_real = self.spatial_discriminator(torch.cat((images, future_images), 1))
@@ -214,7 +212,6 @@ class NowcastingGAN(pl.LightningModule):
 
         # Grid Cell Loss
         grid_loss = self.grid_regularizer(mean_prediction, future_images)
-
         g_loss = spatial_loss + temporal_loss - (self.grid_lambda * grid_loss)
 
         self.log_dict(

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -33,6 +33,7 @@ class NowcastingGAN(pl.LightningModule):
         grid_lambda: float = 20.0,
         beta1: float = 0.0,
         beta2: float = 0.999,
+        latent_channels: int = 768,
     ):
         """
         Nowcasting GAN is an attempt to recreate DeepMind's Skillful Nowcasting GAN from https://arxiv.org/abs/2104.00954
@@ -59,14 +60,19 @@ class NowcastingGAN(pl.LightningModule):
         self.grid_lambda = grid_lambda
         self.num_samples = num_samples
         self.make_vis = make_vis
+        self.latent_channels = latent_channels
         self.input_channels = input_channels
         self.conditioning_stack = ContextConditioningStack(
-            input_channels=input_channels, conv_type=conv_type
+            input_channels=input_channels,
+            conv_type=conv_type,
+            output_channels=self.latent_channels,
         )
         self.latent_stack = LatentConditioningStack(
             shape=(output_shape // 32, output_shape // 32, 8 * self.input_channels)
         )
-        self.sampler = NowcastingSampler(forecast_steps=forecast_steps, input_channels=768)
+        self.sampler = NowcastingSampler(
+            forecast_steps=forecast_steps, input_channels=self.latent_channels
+        )
         self.temporal_discriminator = NowcastingTemporalDiscriminator(
             input_channels=input_channels, crop_size=output_shape // 4
         )

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -198,6 +198,7 @@ class NowcastingGAN(pl.LightningModule):
         for _ in range(self.num_samples):
             mean_prediction.append(self(images))
         # It is a list of tensors of forecasts
+        print(f"Prediction Forecast: {mean_prediction[0].shape}")
         mean_prediction = self.average_tensors(mean_prediction)
         print(f"Mean Prediction: {mean_prediction.shape}")
 

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -1,7 +1,9 @@
 import torch
 import torch.nn.functional as F
+from torch.optim import lr_scheduler
 from typing import Union
-from satflow.models.losses import FocalLoss, get_loss
+from collections import OrderedDict
+from satflow.models.losses import get_loss
 import numpy as np
 import pytorch_lightning as pl
 
@@ -80,33 +82,98 @@ class NowcastingGAN(pl.LightningModule):
         x = self.sampler(conditioning_states, latent_dim)
         return x
 
-    def configure_optimizers(self):
-        # DeepSpeedCPUAdam provides 5x to 7x speedup over torch.optim.adam(w)
-        # optimizer = torch.optim.adam()
-        return torch.optim.Adam(self.parameters(), lr=self.lr)
+    def training_step(self, batch, batch_idx, optimizer_idx):
+        images, future_images, future_masks = batch
+        # train generator
+        if optimizer_idx == 0:
+            # generate images
+            generated_images = self(images)
+            fake = torch.cat((images, generated_images), 1)
+            # log sampled images
+            # if np.random.random() < 0.01:
+            self.visualize_step(images, future_images, generated_images, batch_idx, step="train")
 
-    def training_step(self, batch, batch_idx):
-        x, y = batch
-        y_hat = self(x)
+            # adversarial loss is binary cross-entropy
+            gan_loss = self.criterionGAN(self.discriminator(fake), True)
+            l1_loss = self.criterionL1(generated_images, future_images) * self.lambda_l1
+            g_loss = gan_loss + l1_loss
+            tqdm_dict = {"g_loss": g_loss}
+            output = OrderedDict({"loss": g_loss, "progress_bar": tqdm_dict, "log": tqdm_dict})
+            self.log_dict({"train/g_loss": g_loss})
+            return output
 
-        if self.make_vis:
-            if np.random.random() < 0.001:
-                self.visualize(x, y, y_hat, batch_idx)
-        # Generally only care about the center x crop, so the model can take into account the clouds in the area without
-        # being penalized for that, but for now, just do general MSE loss, also only care about first 12 channels
-        loss = self.criterion(y_hat, y)
-        self.log("train/loss", loss, on_step=True)
-        return loss
+        # train discriminator
+        if optimizer_idx == 1:
+            # Measure discriminator's ability to classify real from generated samples
+
+            # how well can it label as real?
+            real = torch.cat((images, future_images), 1)
+            real_loss = self.criterionGAN(self.discriminator(real), True)
+
+            # how well can it label as fake?
+            gen_output = self(images)
+            fake = torch.cat((images, gen_output), 1)
+            fake_loss = self.criterionGAN(self.discriminator(fake), True)
+
+            # discriminator loss is the average of these
+            d_loss = (real_loss + fake_loss) / 2
+            tqdm_dict = {"d_loss": d_loss}
+            output = OrderedDict({"loss": d_loss, "progress_bar": tqdm_dict, "log": tqdm_dict})
+            self.log_dict({"train/d_loss": d_loss})
+            return output
 
     def validation_step(self, batch, batch_idx):
-        x, y = batch
-        y_hat = self(x)
-        val_loss = self.criterion(y_hat, y)
-        self.log("val/loss", val_loss, on_step=True, on_epoch=True)
-        return val_loss
+        images, future_images, future_masks = batch
+        # generate images
+        generated_images = self(images)
+        fake = torch.cat((images, generated_images), 1)
+        # log sampled images
+        if np.random.random() < 0.01:
+            self.visualize_step(images, future_images, generated_images, batch_idx, step="val")
 
-    def test_step(self, batch, batch_idx):
-        x, y = batch
-        y_hat = self(x)
-        loss = self.criterion(y_hat, y)
-        return loss
+        # adversarial loss is binary cross-entropy
+        gan_loss = self.criterionGAN(self.discriminator(fake), True)
+        l1_loss = self.criterionL1(generated_images, future_images) * self.lambda_l1
+        g_loss = gan_loss + l1_loss
+        # how well can it label as real?
+        real = torch.cat((images, future_images), 1)
+        real_loss = self.criterionGAN(self.discriminator(real), True)
+
+        # how well can it label as fake?
+        fake_loss = self.criterionGAN(self.discriminator(fake), True)
+
+        # discriminator loss is the average of these
+        d_loss = (real_loss + fake_loss) / 2
+        tqdm_dict = {"d_loss": d_loss}
+        output = OrderedDict(
+            {
+                "val/discriminator_loss": d_loss,
+                "val/generator_loss": g_loss,
+                "progress_bar": tqdm_dict,
+                "log": tqdm_dict,
+            }
+        )
+        self.log_dict({"val/d_loss": d_loss, "val/g_loss": g_loss, "val/loss": d_loss + g_loss})
+        return output
+
+    def configure_optimizers(self):
+        lr = self.lr
+        b1 = self.b1
+        b2 = self.b2
+
+        opt_g = torch.optim.Adam(self.generator.parameters(), lr=lr, betas=(b1, b2))
+        opt_d = torch.optim.Adam(self.discriminator.parameters(), lr=lr, betas=(b1, b2))
+        if self.lr_method == "plateau":
+            g_scheduler = lr_scheduler.ReduceLROnPlateau(
+                opt_g, mode="min", factor=0.2, threshold=0.01, patience=10
+            )
+            d_scheduler = lr_scheduler.ReduceLROnPlateau(
+                opt_d, mode="min", factor=0.2, threshold=0.01, patience=10
+            )
+        elif self.lr_method == "cosine":
+            g_scheduler = lr_scheduler.CosineAnnealingLR(opt_g, T_max=self.lr_epochs, eta_min=0)
+            d_scheduler = lr_scheduler.CosineAnnealingLR(opt_d, T_max=self.lr_epochs, eta_min=0)
+        else:
+            return NotImplementedError("learning rate policy is not implemented")
+
+        return [opt_g, opt_d], [g_scheduler, d_scheduler]

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -49,12 +49,14 @@ class NowcastingGAN(pl.LightningModule):
             raise ValueError(f"loss {loss} not recognized")
         self.make_vis = make_vis
         self.input_channels = input_channels
-        self.model = DVDGan(forecast_steps, input_channels, num_layers, hidden_dim, bilinear)
+        self.model = NowcastingGAN(
+            forecast_steps, input_channels, num_layers, hidden_dim, bilinear
+        )
         self.save_hyperparameters()
 
     @classmethod
     def from_config(cls, config):
-        return DVDGan(
+        return NowcastingGAN(
             forecast_steps=config.get("forecast_steps", 12),
             input_channels=config.get("in_channels", 12),
             hidden_dim=config.get("features", 64),
@@ -96,3 +98,41 @@ class NowcastingGAN(pl.LightningModule):
         y_hat = self(x)
         loss = self.criterion(y_hat, y)
         return loss
+
+
+class NowcastingModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        pass
+
+    def temporal_discriminator(self):
+        pass
+
+    def spatial_discriminator(self):
+        pass
+
+    def latent_conditioning_stack(self):
+        pass
+
+    def generator(self):
+        pass
+
+    def space_to_dim(self):
+        pass
+
+    def dim_to_space(self):
+        pass
+
+    def g_block(self):
+        pass
+
+    def d_block(self):
+        pass
+
+    def d3_block(self):
+        pass
+
+    def l_block(self):
+        pass

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -20,6 +20,7 @@ class NowcastingGAN(pl.LightningModule):
         self,
         forecast_steps: int,
         input_channels: int = 3,
+        output_shape: int = 256,
         hidden_dim: int = 64,
         bilinear: bool = False,
         lr: float = 0.001,
@@ -50,10 +51,12 @@ class NowcastingGAN(pl.LightningModule):
         self.conditioning_stack = ContextConditioningStack(
             input_channels=input_channels, conv_type=conv_type
         )
-        self.latent_stack = LatentConditioningStack(shape=(8, 8, 8))
+        self.latent_stack = LatentConditioningStack(
+            shape=(output_shape // 32, output_shape // 32, 8 * self.input_channels)
+        )
         self.sampler = NowcastingSampler(forecast_steps=forecast_steps, input_channels=768)
         self.temporal_discriminator = NowcastingTemporalDiscriminator(
-            input_channels=input_channels, crop_size=64
+            input_channels=input_channels, crop_size=output_shape // 4
         )
         self.spatial_discriminator = NowcastingSpatialDiscriminator(
             input_channels=input_channels, num_timesteps=8

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -9,7 +9,7 @@ from satflow.models.base import register_model
 
 
 @register_model
-class DVDGan(pl.LightningModule):
+class NowcastingGAN(pl.LightningModule):
     def __init__(
         self,
         forecast_steps: int,
@@ -22,7 +22,21 @@ class DVDGan(pl.LightningModule):
         loss: Union[str, torch.nn.Module] = "mse",
         pretrained: bool = False,
     ):
-        super(DVDGan, self).__init__()
+        """
+        Nowcasting GAN is an attempt to recreate DeepMind's Skillful Nowcasting GAN from https://arxiv.org/abs/2104.00954
+        but slightly modified for multiple satellite channels
+        Args:
+            forecast_steps:
+            input_channels:
+            num_layers:
+            hidden_dim:
+            bilinear:
+            lr:
+            make_vis:
+            loss:
+            pretrained:
+        """
+        super(NowcastingGAN, self).__init__()
         self.lr = lr
         assert loss in ["mse", "bce", "binary_crossentropy", "crossentropy", "focal"]
         if loss == "mse":

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -67,7 +67,7 @@ class NowcastingGAN(pl.LightningModule):
             output_channels=self.latent_channels,
         )
         self.latent_stack = LatentConditioningStack(
-            shape=(output_shape // 32, output_shape // 32, 8 * self.input_channels)
+            shape=(8 * self.input_channels, output_shape // 32, output_shape // 32)
         )
         self.sampler = NowcastingSampler(
             forecast_steps=forecast_steps, input_channels=self.latent_channels
@@ -278,6 +278,6 @@ class NowcastingGenerator(torch.nn.Module):
 
     def forward(self, x):
         conditioning_states = self.conditioning_stack(x)
-        latent_dim = self.latent_stack()
+        latent_dim = self.latent_stack(x)
         x = self.sampler(conditioning_states, latent_dim)
         return x

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -67,7 +67,8 @@ class NowcastingGAN(pl.LightningModule):
             output_channels=self.latent_channels,
         )
         self.latent_stack = LatentConditioningStack(
-            shape=(8 * self.input_channels, output_shape // 32, output_shape // 32)
+            shape=(8 * self.input_channels, output_shape // 32, output_shape // 32),
+            output_channels=self.latent_channels,
         )
         self.sampler = NowcastingSampler(
             forecast_steps=forecast_steps, input_channels=self.latent_channels

--- a/satflow/models/nowcasting_gan.py
+++ b/satflow/models/nowcasting_gan.py
@@ -231,7 +231,7 @@ class NowcastingGAN(pl.LightningModule):
 
     def visualize_step(
         self, x: torch.Tensor, y: torch.Tensor, y_hat: torch.Tensor, batch_idx: int, step: str
-    ):
+    ) -> None:
         # the logger you used (in this case tensorboard)
         tensorboard = self.logger.experiment[0]
         # Timesteps per channel

--- a/satflow/models/utils.py
+++ b/satflow/models/utils.py
@@ -1,4 +1,5 @@
 import torch
+from torch.nn.utils.spectral_norm import spectral_norm
 from satflow.models.layers import CoordConv
 
 

--- a/satflow/models/utils.py
+++ b/satflow/models/utils.py
@@ -1,5 +1,4 @@
 import torch
-from torch.nn.utils.spectral_norm import spectral_norm
 from satflow.models.layers import CoordConv
 
 

--- a/satflow/models/utils.py
+++ b/satflow/models/utils.py
@@ -4,12 +4,14 @@ from satflow.models.layers import CoordConv
 
 def get_conv_layer(conv_type: str = "standard") -> torch.nn.Module:
     if conv_type == "standard":
-        conv2d = torch.nn.Conv2d
+        conv_layer = torch.nn.Conv2d
     elif conv_type == "coord":
-        conv2d = CoordConv
+        conv_layer = CoordConv
     elif conv_type == "antialiased":
         # TODO Add anti-aliased coordconv here
-        conv2d = torch.nn.Conv2d
+        conv_layer = torch.nn.Conv2d
+    elif conv_type == "3d":
+        conv_layer = torch.nn.Conv3d
     else:
         raise ValueError(f"{conv_type} is not a recognized Conv method")
-    return conv2d
+    return conv_layer


### PR DESCRIPTION
Nowcasting GAN is my name for the DeepMind model from here: https://arxiv.org/abs/2104.00954 As now there is a structure for GANs in satflow, and some somewhat similar ones, like CloudGAN are ready to go and being experimented with, this is to try tackling making this model. Luckily the paper is super detailed, so just have to follow along with that, apparently training it is difficult though.

 One part that would be I think very useful for other GANs in this repo is the temporal/spatial discriminators that are used, with each one focusing on a different aspect of the output. 

Additionally adds Docker support, to make it easier to deploy on cloud providers, as these models are getting quite large for local development. 

Things that need to be implemented for the GAN:

- [x] Spatial Discriminator
- [x] Temporal Discriminator
- [x] Space2Depth and Depth2Space layers (Turns out they exist in PyTorch under PixelShuffle/UnShuffle)
- [x] Latent Space to Input layer
- [x] Context Frames to multi-level inputs (256x256 -> 64x64, 32x32, 16x16, 8x8) 
- [x] GBlock
- [x] Attention module in LatentConditioningStack
- [x] LightningModule
- [x] Loss Function
- [x] Docker Support
- [ ] Test it trains