### PR TITLE
Add `PyTorchModelHubMixin` to `BaseModel`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.8
+  python: python3.9
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ torchvision>=0.10.0
 affine==2.3.0
 git+https://github.com/webdataset/webdataset
 torch_optimizer
-huggingface_hub
+huggingface_hub>=0.0.16
+einops==0.3.2

--- a/satflow/models/base.py
+++ b/satflow/models/base.py
@@ -13,6 +13,9 @@ MODEL_CARD_MARKDOWN = """---
 license: mit
 tags:
 - satflow
+- forecasting
+- timeseries
+- remote-sensing
 ---
 
 # {model_name}

--- a/satflow/models/base.py
+++ b/satflow/models/base.py
@@ -4,6 +4,7 @@ import pytorch_lightning as pl
 import torchvision
 from neptune.new.types import File
 from satflow.models.hub import load_model_config_from_hf, load_pretrained
+from huggingface_hub import PyTorchModelHubMixin
 
 REGISTERED_MODELS = {}
 
@@ -98,7 +99,7 @@ def create_model(model_name, pretrained=False, checkpoint_path=None, **kwargs):
     return model
 
 
-class BaseModel(pl.LightningModule):
+class BaseModel(pl.LightningModule, PyTorchModelHubMixin):
     def __init__(
         self,
         pretrained: bool = False,

--- a/satflow/models/base.py
+++ b/satflow/models/base.py
@@ -4,9 +4,48 @@ import pytorch_lightning as pl
 import torchvision
 from neptune.new.types import File
 from satflow.models.hub import load_model_config_from_hf, load_pretrained
-from huggingface_hub import PyTorchModelHubMixin
+from huggingface_hub import PyTorchModelHubMixin, PYTORCH_WEIGHTS_NAME
+import os
 
 REGISTERED_MODELS = {}
+
+MODEL_CARD_MARKDOWN = """---
+license: mit
+tags:
+- satflow
+---
+
+# {model_name}
+
+## Model description
+
+[More information needed]
+
+## Intended uses & limitations
+
+[More information needed]
+
+## How to use
+
+[More information needed]
+
+## Limitations and bias
+
+[More information needed]
+
+## Training data
+
+[More information needed]
+
+## Training procedure
+
+[More information needed]
+
+## Evaluation results
+
+[More information needed]
+
+"""
 
 
 def register_model(cls: Type[pl.LightningModule]):
@@ -162,3 +201,14 @@ class BaseModel(pl.LightningModule, PyTorchModelHubMixin):
             )
             image_grid = image_grid.permute(1, 2, 0)
             tensorboard[f"{step}/Predicted_Frame_{i}"].log(File.as_image(image_grid.numpy()))
+
+    def _create_model_card(self, path):
+        model_card = MODEL_CARD_MARKDOWN.format(model_name=type(self).__name__)
+        with open(os.path.join(path, "README.md"), "w") as f:
+            f.write(model_card)
+
+    def _save_pretrained(self, save_directory: str):
+        path = os.path.join(save_directory, PYTORCH_WEIGHTS_NAME)
+        model_to_save = self.module if hasattr(self, "module") else self
+        torch.save(model_to_save.state_dict(), path)
+        self._create_model_card(save_directory)


### PR DESCRIPTION
This PR add a [mixin](https://github.com/huggingface/huggingface_hub/blob/94916a3ccf3c09cab38cde9bd9264fcfde97a574/src/huggingface_hub/hub_mixin.py#L286) so that all models derived from `BaseModel` inherit `.from_pretrained` and `.push_to_hub` functions that allow end-users to pull / push weights via the Hugging Face Hub.

Here's a demo using `MetNet` (make sure you have Git LFS installed with e.g. `apt install git-lfs`):

```python
from satflow.models import MetNet
import numpy as np
import torch
import urllib.request
import huggingface_hub

# Load pretrained model from local weights
config = {"input_channels":17, "sat_channels":13, "input_size":64, "hidden_dim":32, "output_channels":1, "forecast_steps":24}
model = MetNet.load_from_checkpoint("metnet_segmentation.ckpt", **config)
torch.set_grad_enabled(False)
model.eval();

# Push weights to Hugging Face Hub
# Assumes a token already exists from `huggingface-cli login`
# Example https://huggingface.co/lewtun/metnet-test
model.push_to_hub("metnet-test")

# Pull pretrained weights from the Hub - in eval mode by default
hub_model = MetNet.from_pretrained("lewtun/metnet-test", **config)

# Check we get the same tensor shapes
def get_input(number: int):
    url = f"https://github.com/openclimatefix/satflow/releases/download/v0.0.3/input_{number}.pth"
    filename, headers = urllib.request.urlretrieve(url, filename=f"input_{number}.pth")
    input_data = torch.load(filename)
    return input_data

for i in range(11):
    local_forecast = model(get_input(i))
    hub_forecast = hub_model(get_input(i))
    assert local_forecast.size() == hub_forecast.size()
```

I also took the liberty of adding a missing dependency to `requirements.txt` and bumping the Python version in the pre-commit hooks to match the Python version created by `conda`.