### PR TITLE
Refactor BaseModel to save and load model config

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -1,6 +1,12 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/satflow/models/base.py
+++ b/satflow/models/base.py
@@ -3,52 +3,10 @@ import torch.nn
 import pytorch_lightning as pl
 import torchvision
 from neptune.new.types import File
-from satflow.models.hub import load_model_config_from_hf, load_pretrained
-from huggingface_hub import PyTorchModelHubMixin, PYTORCH_WEIGHTS_NAME
-import os
+from satflow.models.hub import load_model_config_from_hf, load_pretrained, SatFlowModelHubMixin
+
 
 REGISTERED_MODELS = {}
-
-MODEL_CARD_MARKDOWN = """---
-license: mit
-tags:
-- satflow
-- forecasting
-- timeseries
-- remote-sensing
----
-
-# {model_name}
-
-## Model description
-
-[More information needed]
-
-## Intended uses & limitations
-
-[More information needed]
-
-## How to use
-
-[More information needed]
-
-## Limitations and bias
-
-[More information needed]
-
-## Training data
-
-[More information needed]
-
-## Training procedure
-
-[More information needed]
-
-## Evaluation results
-
-[More information needed]
-
-"""
 
 
 def register_model(cls: Type[pl.LightningModule]):
@@ -141,7 +99,7 @@ def create_model(model_name, pretrained=False, checkpoint_path=None, **kwargs):
     return model
 
 
-class BaseModel(pl.LightningModule, PyTorchModelHubMixin):
+class BaseModel(pl.LightningModule, SatFlowModelHubMixin):
     def __init__(
         self,
         pretrained: bool = False,
@@ -204,14 +162,3 @@ class BaseModel(pl.LightningModule, PyTorchModelHubMixin):
             )
             image_grid = image_grid.permute(1, 2, 0)
             tensorboard[f"{step}/Predicted_Frame_{i}"].log(File.as_image(image_grid.numpy()))
-
-    def _create_model_card(self, path):
-        model_card = MODEL_CARD_MARKDOWN.format(model_name=type(self).__name__)
-        with open(os.path.join(path, "README.md"), "w") as f:
-            f.write(model_card)
-
-    def _save_pretrained(self, save_directory: str):
-        path = os.path.join(save_directory, PYTORCH_WEIGHTS_NAME)
-        model_to_save = self.module if hasattr(self, "module") else self
-        torch.save(model_to_save.state_dict(), path)
-        self._create_model_card(save_directory)

--- a/satflow/models/hub.py
+++ b/satflow/models/hub.py
@@ -189,26 +189,24 @@ def load_pretrained(
 class SatFlowModelHubMixin(ModelHubMixin):
     def __init__(self, *args, **kwargs):
         """
-        Mix this class with your torch-model class for ease process of saving & loading from
+        Mix this class with your pl.LightningModule class to easily push / download the model via the Hugging Face Hub
 
         Example::
 
-            >>> from huggingface_hub import PyTorchModelHubMixin
+            >>> from satflow.models.hub import SatFlowModelHubMixin
 
-            >>> class MyModel(nn.Module, PyTorchModelHubMixin):
+            >>> class MyModel(nn.Module, SatFlowModelHubMixin):
             ...    def __init__(self, **kwargs):
             ...        super().__init__()
-            ...        self.config = kwargs.pop("config", None)
             ...        self.layer = ...
             ...    def forward(self, ...)
             ...        return ...
 
             >>> model = MyModel()
-            >>> model.save_pretrained("mymodel", push_to_hub=False) # Saving model weights in the directory
-            >>> model.push_to_hub("mymodel", "model-1") # Pushing model-weights to hf-hub
+            >>> model.push_to_hub("mymodel") # Pushing model-weights to hf-hub
 
             >>> # Downloading weights from hf-hub & model will be initialized from those weights
-            >>> model = MyModel.from_pretrained("username/mymodel@main")
+            >>> model = MyModel.from_pretrained("username/mymodel")
         """
 
     def _create_model_card(self, path):

--- a/satflow/models/hub.py
+++ b/satflow/models/hub.py
@@ -27,6 +27,50 @@ except ImportError:
     hf_hub_url = None
     cached_download = None
 
+from huggingface_hub import ModelHubMixin, PYTORCH_WEIGHTS_NAME, CONFIG_NAME, hf_hub_download
+import os
+
+MODEL_CARD_MARKDOWN = """---
+license: mit
+tags:
+- satflow
+- forecasting
+- timeseries
+- remote-sensing
+---
+
+# {model_name}
+
+## Model description
+
+[More information needed]
+
+## Intended uses & limitations
+
+[More information needed]
+
+## How to use
+
+[More information needed]
+
+## Limitations and bias
+
+[More information needed]
+
+## Training data
+
+[More information needed]
+
+## Training procedure
+
+[More information needed]
+
+## Evaluation results
+
+[More information needed]
+
+"""
+
 _logger = logging.getLogger(__name__)
 
 
@@ -142,3 +186,91 @@ def load_pretrained(
 
     model.load_state_dict(state_dict, strict=strict)
     return model
+
+
+class SatFlowModelHubMixin(ModelHubMixin):
+    def __init__(self, *args, **kwargs):
+        """
+        Mix this class with your torch-model class for ease process of saving & loading from
+
+        Example::
+
+            >>> from huggingface_hub import PyTorchModelHubMixin
+
+            >>> class MyModel(nn.Module, PyTorchModelHubMixin):
+            ...    def __init__(self, **kwargs):
+            ...        super().__init__()
+            ...        self.config = kwargs.pop("config", None)
+            ...        self.layer = ...
+            ...    def forward(self, ...)
+            ...        return ...
+
+            >>> model = MyModel()
+            >>> model.save_pretrained("mymodel", push_to_hub=False) # Saving model weights in the directory
+            >>> model.push_to_hub("mymodel", "model-1") # Pushing model-weights to hf-hub
+
+            >>> # Downloading weights from hf-hub & model will be initialized from those weights
+            >>> model = MyModel.from_pretrained("username/mymodel@main")
+        """
+
+    def _create_model_card(self, path):
+        model_card = MODEL_CARD_MARKDOWN.format(model_name=type(self).__name__)
+        with open(os.path.join(path, "README.md"), "w") as f:
+            f.write(model_card)
+
+    def _save_config(self, module, save_directory):
+        config = dict(module.hparams)
+        path = os.path.join(save_directory, CONFIG_NAME)
+        with open(path, "w") as f:
+            json.dump(config, f)
+
+    def _save_pretrained(self, save_directory: str, save_config: bool = True):
+        # Save model weights
+        path = os.path.join(save_directory, PYTORCH_WEIGHTS_NAME)
+        model_to_save = self.module if hasattr(self, "module") else self
+        torch.save(model_to_save.state_dict(), path)
+        # Save model config
+        if save_config and model_to_save.hparams:
+            self._save_config(model_to_save, save_directory)
+        # Save model card
+        self._create_model_card(save_directory)
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        model_id,
+        revision,
+        cache_dir,
+        force_download,
+        proxies,
+        resume_download,
+        local_files_only,
+        use_auth_token,
+        map_location="cpu",
+        strict=False,
+        **model_kwargs,
+    ):
+        map_location = torch.device(map_location)
+
+        if os.path.isdir(model_id):
+            print("Loading weights from local directory")
+            model_file = os.path.join(model_id, PYTORCH_WEIGHTS_NAME)
+        else:
+            model_file = hf_hub_download(
+                repo_id=model_id,
+                filename=PYTORCH_WEIGHTS_NAME,
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                proxies=proxies,
+                resume_download=resume_download,
+                use_auth_token=use_auth_token,
+                local_files_only=local_files_only,
+            )
+        model = cls(**model_kwargs["config"])
+
+        state_dict = torch.load(model_file, map_location=map_location)
+        model.load_state_dict(state_dict, strict=strict)
+        model.eval()
+
+        return model

--- a/satflow/models/hub.py
+++ b/satflow/models/hub.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 from functools import partial
-from typing import Union, Optional
+from typing import Optional, Union
 
 import pytorch_lightning
 import torch
@@ -19,16 +19,14 @@ except ImportError:
 from satflow import __version__
 
 try:
-    from huggingface_hub import hf_hub_url
-    from huggingface_hub import cached_download
+    from huggingface_hub import cached_download, hf_hub_url
 
     cached_download = partial(cached_download, library_name="satflow", library_version=__version__)
 except ImportError:
     hf_hub_url = None
     cached_download = None
 
-from huggingface_hub import ModelHubMixin, PYTORCH_WEIGHTS_NAME, CONFIG_NAME, hf_hub_download
-import os
+from huggingface_hub import CONFIG_NAME, PYTORCH_WEIGHTS_NAME, ModelHubMixin, hf_hub_download
 
 MODEL_CARD_MARKDOWN = """---
 license: mit

--- a/satflow/models/perceiver.py
+++ b/satflow/models/perceiver.py
@@ -156,6 +156,8 @@ class Perceiver(BaseModel):
         else:
             self.postprocessor = None
 
+        self.save_hyperparameters()
+
     def encode_inputs(self, x: torch.Tensor) -> Dict[str, torch.Tensor]:
         video_inputs = x[:, :, : self.sat_channels, :, :]
         base_inputs = x[

--- a/satflow/models/pl_metnet.py
+++ b/satflow/models/pl_metnet.py
@@ -7,6 +7,8 @@ from satflow.models.losses import get_loss
 from pl_bolts.optimizers.lr_scheduler import LinearWarmupCosineAnnealingLR
 from metnet import MetNet
 
+head_to_module = {"identity": nn.Identity()}
+
 
 @register_model
 class LitMetNet(BaseModel):
@@ -21,7 +23,7 @@ class LitMetNet(BaseModel):
         kernel_size: int = 3,
         num_layers: int = 1,
         num_att_layers: int = 1,
-        head: nn.Module = nn.Identity(),
+        head: str = "identity",
         forecast_steps: int = 48,
         temporal_dropout: float = 0.2,
         lr: float = 0.001,
@@ -49,10 +51,13 @@ class LitMetNet(BaseModel):
             kernel_size=kernel_size,
             num_layers=num_layers,
             num_att_layers=num_att_layers,
-            head=head,
+            head=head_to_module[head],
             forecast_steps=forecast_steps,
             temporal_dropout=temporal_dropout,
         )
+        # TODO: Would be nice to have this automatically applied to all classes
+        # that inherit from BaseModel
+        self.save_hyperparameters()
 
     def forward(self, imgs, **kwargs) -> Any:
         return self.model(imgs)

--- a/satflow/tests/test_hub.py
+++ b/satflow/tests/test_hub.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+
+from satflow.models.base import BaseModel
+from satflow.models.hub import SatFlowModelHubMixin
+
+
+class DummyModel(BaseModel, SatFlowModelHubMixin):
+    # Define hyperparameters of various types to test serialisation / deserialisation
+    # This follows the pattern adopted in LitMetNet and Perceiver
+    def __init__(
+        self, loss: str = "mse", forecast_steps: int = 42, pretrained: bool = True, lr: float = 0.05
+    ):
+        super(BaseModel, self).__init__()
+        self.loss = loss
+        self.forecast_steps = forecast_steps
+        self.pretrained = pretrained
+        self.lr = lr
+        self.save_hyperparameters()
+
+
+def test_satflow_mixin():
+    # Override some of the hyperparameters
+    config = {"loss": "rmse", "forecast_steps": 123}
+    model = DummyModel(**config)
+    with tempfile.TemporaryDirectory() as storage_folder:
+        # Save model weights, config, and model card
+        model.save_pretrained(storage_folder)
+        folder_contents = os.listdir(storage_folder)
+        assert len(folder_contents) == 3
+        assert "README.md" in folder_contents
+        assert "pytorch_model.bin" in folder_contents
+        assert "config.json" in folder_contents
+        # Load new model and compare hyperparameters
+        new_model = DummyModel.from_pretrained(storage_folder)
+        assert new_model.hparams == model.hparams

--- a/satflow/tests/test_hub.py
+++ b/satflow/tests/test_hub.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 
+from huggingface_hub import CONFIG_NAME, PYTORCH_WEIGHTS_NAME
+
 from satflow.models.base import BaseModel
 from satflow.models.hub import SatFlowModelHubMixin
 
@@ -29,8 +31,8 @@ def test_satflow_mixin():
         folder_contents = os.listdir(storage_folder)
         assert len(folder_contents) == 3
         assert "README.md" in folder_contents
-        assert "pytorch_model.bin" in folder_contents
-        assert "config.json" in folder_contents
+        assert PYTORCH_WEIGHTS_NAME in folder_contents
+        assert CONFIG_NAME in folder_contents
         # Load new model and compare hyperparameters
         new_model = DummyModel.from_pretrained(storage_folder)
         assert new_model.hparams == model.hparams


### PR DESCRIPTION
# Pull Request Template

## Description

In PR #90 we added a feature to push / download model weights from the Hugging Face Hub. One missing piece was the need to manually initialise a model with the same hyperparameters that it was saved with. 

This PR addresses this limitation by rolling our own `ModelHubMixin` to (mostly) preserve backwards compatibility. The main breaking change is the change of the `head` argument in `LitMetNet` from a PyTorch module to a `str` that we then map during the model initialisation.

### Example usage

```python
from satflow.models import LitMetNet

# Initialise model with custom parameters
config = {"input_channels":17, "sat_channels":13, "input_size":64, "hidden_dim":32, "output_channels":1, "forecast_steps":24}
model = LitMetNet(**config)
# Push weights and config to the HF Hub
# URL: https://huggingface.co/lewtun/litmetnet-test-01
model.push_to_hub("litmetnet-test-01")
# Initialise a new model from the Hub
new_model = LitMetNet.from_pretrained("lewtun/litmetnet-test-01")
# Check hyperparameters agree
assert model.hparams == new_model.hparams
```

TODO:

- [x] Add tests
- [ ] Figure out a better way to save hyperparameters using Lightning hooks (opened discussion [here](https://github.com/PyTorchLightning/pytorch-lightning/discussions/9509))
- [x] Clean up `SatFlowModelHubMixin` docstring

## How Has This Been Tested?

I have created a new unit test under `test_hub.py` which tests that:

* The `SatFlowModelHubMixin` saves the correct number of files
* The hyperparameters agree before and after saving a model

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
